### PR TITLE
feat: MCP graph query tools — symbol_at, find_callers, find_callees, find_dependents (#20)

### DIFF
--- a/src/graph/query.zig
+++ b/src/graph/query.zig
@@ -1,0 +1,274 @@
+// CodeGraph DB — graph query functions
+//
+// Higher-level queries built on top of CodeGraph: symbol_at, find_callers,
+// find_callees, find_dependents. These are the core operations exposed
+// via MCP tools to the agent.
+
+const std = @import("std");
+const types = @import("types.zig");
+const graph_mod = @import("graph.zig");
+const ppr_mod = @import("ppr.zig");
+const CodeGraph = graph_mod.CodeGraph;
+const Symbol = types.Symbol;
+const Edge = types.Edge;
+const EdgeKind = types.EdgeKind;
+
+// ── Query results ───────────────────────────────────────────────────────────
+
+pub const SymbolResult = struct {
+    id: u64,
+    name: []const u8,
+    kind: types.SymbolKind,
+    file_path: []const u8,
+    line: u32,
+    col: u16,
+    scope: []const u8,
+};
+
+pub const CallerResult = struct {
+    symbol: SymbolResult,
+    edge_kind: EdgeKind,
+    weight: f32,
+};
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+/// Find all symbols defined at a given file path and line number.
+/// Returns all symbols at that exact line, or the closest symbol if none match exactly.
+pub fn symbolAt(
+    g: *const CodeGraph,
+    file_path: []const u8,
+    line: u32,
+    alloc: std.mem.Allocator,
+) ![]SymbolResult {
+    // Find the file ID for this path
+    const file_id = findFileId(g, file_path) orelse return &.{};
+
+    // Collect symbols at this file + line
+    var results: std.ArrayList(SymbolResult) = .empty;
+    defer results.deinit(alloc);
+
+    var sym_it = g.symbols.iterator();
+    while (sym_it.next()) |entry| {
+        const sym = entry.value_ptr.*;
+        if (sym.file_id == file_id and sym.line == line) {
+            try results.append(alloc, makeSymbolResult(g, sym));
+        }
+    }
+
+    // If no exact match, find closest symbol before this line
+    if (results.items.len == 0) {
+        var best: ?Symbol = null;
+        var best_dist: u32 = std.math.maxInt(u32);
+        sym_it = g.symbols.iterator();
+        while (sym_it.next()) |entry| {
+            const sym = entry.value_ptr.*;
+            if (sym.file_id == file_id and sym.line <= line) {
+                const dist = line - sym.line;
+                if (dist < best_dist) {
+                    best_dist = dist;
+                    best = sym;
+                }
+            }
+        }
+        if (best) |sym| {
+            try results.append(alloc, makeSymbolResult(g, sym));
+        }
+    }
+
+    const out = try alloc.alloc(SymbolResult, results.items.len);
+    @memcpy(out, results.items);
+    return out;
+}
+
+/// Find all callers of a symbol (nodes with edges pointing to it).
+pub fn findCallers(
+    g: *const CodeGraph,
+    symbol_id: u64,
+    alloc: std.mem.Allocator,
+) ![]CallerResult {
+    const in = g.inEdges(symbol_id);
+
+    var results: std.ArrayList(CallerResult) = .empty;
+    defer results.deinit(alloc);
+
+    for (in) |edge| {
+        const sym = g.getSymbol(edge.src) orelse continue;
+        try results.append(alloc, .{
+            .symbol = makeSymbolResult(g, sym),
+            .edge_kind = edge.kind,
+            .weight = edge.weight,
+        });
+    }
+
+    const out = try alloc.alloc(CallerResult, results.items.len);
+    @memcpy(out, results.items);
+    return out;
+}
+
+/// Find all callees of a symbol (nodes it has edges pointing to).
+pub fn findCallees(
+    g: *const CodeGraph,
+    symbol_id: u64,
+    alloc: std.mem.Allocator,
+) ![]CallerResult {
+    const edges = g.outEdges(symbol_id);
+
+    var results: std.ArrayList(CallerResult) = .empty;
+    defer results.deinit(alloc);
+
+    for (edges) |edge| {
+        const sym = g.getSymbol(edge.dst) orelse continue;
+        try results.append(alloc, .{
+            .symbol = makeSymbolResult(g, sym),
+            .edge_kind = edge.kind,
+            .weight = edge.weight,
+        });
+    }
+
+    const out = try alloc.alloc(CallerResult, results.items.len);
+    @memcpy(out, results.items);
+    return out;
+}
+
+/// Find all symbols that depend on the given symbol, ranked by PPR score.
+/// This uses Personalized PageRank to find the most relevant dependents,
+/// not just direct callers but transitive ones weighted by graph structure.
+pub fn findDependents(
+    g: *const CodeGraph,
+    symbol_id: u64,
+    max_results: usize,
+    alloc: std.mem.Allocator,
+) ![]ppr_mod.ScoredNode {
+    var scores = try ppr_mod.pprPush(g, symbol_id, ppr_mod.DEFAULT_ALPHA, ppr_mod.DEFAULT_EPSILON, alloc);
+    defer scores.deinit();
+
+    const top = try ppr_mod.topK(&scores, max_results, symbol_id, alloc);
+    return top;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn findFileId(g: *const CodeGraph, path: []const u8) ?u32 {
+    var it = g.files.iterator();
+    while (it.next()) |entry| {
+        if (std.mem.eql(u8, entry.value_ptr.path, path)) return entry.key_ptr.*;
+    }
+    return null;
+}
+
+fn makeSymbolResult(g: *const CodeGraph, sym: Symbol) SymbolResult {
+    const file_path = if (g.getFile(sym.file_id)) |f| f.path else "";
+    return .{
+        .id = sym.id,
+        .name = sym.name,
+        .kind = sym.kind,
+        .file_path = file_path,
+        .line = sym.line,
+        .col = sym.col,
+        .scope = sym.scope,
+    };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+fn buildTestGraph(alloc: std.mem.Allocator) !CodeGraph {
+    var g = CodeGraph.init(alloc);
+
+    try g.addFile(.{ .id = 1, .path = "src/main.ts", .language = .typescript, .last_modified = 0, .hash = [_]u8{0} ** 32 });
+    try g.addFile(.{ .id = 2, .path = "src/utils.ts", .language = .typescript, .last_modified = 0, .hash = [_]u8{0} ** 32 });
+
+    try g.addSymbol(.{ .id = 10, .name = "main", .kind = .function, .file_id = 1, .line = 1, .col = 0, .scope = "" });
+    try g.addSymbol(.{ .id = 20, .name = "handleRequest", .kind = .function, .file_id = 1, .line = 10, .col = 0, .scope = "" });
+    try g.addSymbol(.{ .id = 30, .name = "formatOutput", .kind = .function, .file_id = 2, .line = 5, .col = 0, .scope = "" });
+    try g.addSymbol(.{ .id = 40, .name = "validate", .kind = .function, .file_id = 2, .line = 20, .col = 0, .scope = "" });
+
+    // main → handleRequest → formatOutput
+    // main → validate
+    try g.addEdge(.{ .src = 10, .dst = 20, .kind = .calls, .weight = 2.0 });
+    try g.addEdge(.{ .src = 20, .dst = 30, .kind = .calls });
+    try g.addEdge(.{ .src = 10, .dst = 40, .kind = .calls });
+
+    return g;
+}
+
+test "symbolAt finds exact line match" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    const results = try symbolAt(&g, "src/main.ts", 10, std.testing.allocator);
+    defer std.testing.allocator.free(results);
+
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqualStrings("handleRequest", results[0].name);
+    try std.testing.expectEqualStrings("src/main.ts", results[0].file_path);
+}
+
+test "symbolAt finds closest symbol before line" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    // Line 15 is between handleRequest (10) and nothing — should find handleRequest
+    const results = try symbolAt(&g, "src/main.ts", 15, std.testing.allocator);
+    defer std.testing.allocator.free(results);
+
+    try std.testing.expectEqual(@as(usize, 1), results.len);
+    try std.testing.expectEqualStrings("handleRequest", results[0].name);
+}
+
+test "symbolAt returns empty for unknown file" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    const results = try symbolAt(&g, "nonexistent.ts", 1, std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), results.len);
+}
+
+test "findCallers returns in-edges" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    // handleRequest (20) is called by main (10)
+    const callers = try findCallers(&g, 20, std.testing.allocator);
+    defer std.testing.allocator.free(callers);
+
+    try std.testing.expectEqual(@as(usize, 1), callers.len);
+    try std.testing.expectEqualStrings("main", callers[0].symbol.name);
+    try std.testing.expectEqual(EdgeKind.calls, callers[0].edge_kind);
+}
+
+test "findCallees returns out-edges" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    // main (10) calls handleRequest (20) and validate (40)
+    const callees = try findCallees(&g, 10, std.testing.allocator);
+    defer std.testing.allocator.free(callees);
+
+    try std.testing.expectEqual(@as(usize, 2), callees.len);
+}
+
+test "findDependents uses PPR ranking" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    const deps = try findDependents(&g, 10, 5, std.testing.allocator);
+    defer std.testing.allocator.free(deps);
+
+    // Should find dependents ranked by PPR score
+    try std.testing.expect(deps.len > 0);
+    // Scores should be descending
+    for (0..deps.len - 1) |i| {
+        try std.testing.expect(deps[i].score >= deps[i + 1].score);
+    }
+}
+
+test "findCallers on node with no callers returns empty" {
+    var g = try buildTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    const callers = try findCallers(&g, 10, std.testing.allocator);
+    defer std.testing.allocator.free(callers);
+
+    try std.testing.expectEqual(@as(usize, 0), callers.len);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -238,4 +238,5 @@ test {
     _ = @import("graph/storage.zig");
     _ = @import("graph/wal.zig");
     _ = @import("graph/hot_cache.zig");
+    _ = @import("graph/query.zig");
 }


### PR DESCRIPTION
## Summary

- **`src/graph/query.zig`** — high-level graph query functions:
  - `symbolAt(graph, file, line)` — find symbol at file:line, falls back to closest
  - `findCallers(graph, id)` — all in-edges (who calls this)
  - `findCallees(graph, id)` — all out-edges (what it calls)
  - `findDependents(graph, id, k)` — PPR-ranked transitive dependents
- **4 new MCP tools** registered in `tools.zig`: `symbol_at`, `find_callers`, `find_callees`, `find_dependents`
- Tools load CodeGraph from `.codegraph/graph.bin` on each call
- Returns JSON with symbol metadata (name, kind, file, line, col, scope), edge kinds, and weights

## Test plan
- [x] `zig build` — compiles cleanly
- [x] `zig build test` — 67/67 tests pass (60 existing + 7 new)
- [x] symbolAt exact line match
- [x] symbolAt closest-before-line fallback
- [x] symbolAt unknown file returns empty
- [x] findCallers returns in-edges with metadata
- [x] findCallees returns out-edges
- [x] findDependents PPR ranking (descending scores)
- [x] findCallers on root node returns empty

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)