### PR TITLE
test: edge case tests for storage and persistence

### DIFF
--- a/src/graph/hot_cache.zig
+++ b/src/graph/hot_cache.zig
@@ -278,3 +278,221 @@ test "sequential eviction order" {
     try std.testing.expectEqual(@as(?u32, 40), cache.get(4));
     try std.testing.expectEqual(@as(?u32, 50), cache.get(5));
 }
+
+// ── Edge case tests ─────────────────────────────────────────────────────────
+
+test "get from empty cache returns null" {
+    var cache = LruCache(u32).init(std.testing.allocator, 10);
+    defer cache.deinit();
+
+    try std.testing.expectEqual(@as(?u32, null), cache.get(0));
+    try std.testing.expectEqual(@as(?u32, null), cache.get(1));
+    try std.testing.expectEqual(@as(?u32, null), cache.get(std.math.maxInt(u64)));
+    try std.testing.expectEqual(@as(usize, 0), cache.count());
+}
+
+test "put same key multiple times updates value each time" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(1, 100);
+    try std.testing.expectEqual(@as(?u32, 100), cache.get(1));
+    try std.testing.expectEqual(@as(usize, 1), cache.count());
+
+    try cache.put(1, 200);
+    try std.testing.expectEqual(@as(?u32, 200), cache.get(1));
+    try std.testing.expectEqual(@as(usize, 1), cache.count());
+
+    try cache.put(1, 300);
+    try std.testing.expectEqual(@as(?u32, 300), cache.get(1));
+    try std.testing.expectEqual(@as(usize, 1), cache.count());
+
+    // Ensure only one entry exists
+    try cache.put(1, 400);
+    try std.testing.expectEqual(@as(usize, 1), cache.count());
+    try std.testing.expectEqual(@as(?u32, 400), cache.get(1));
+}
+
+test "capacity=1 cycling through many keys" {
+    var cache = LruCache(u32).init(std.testing.allocator, 1);
+    defer cache.deinit();
+
+    // Cycle through 20 different keys — each should evict the previous
+    for (0..20) |i| {
+        const key: u64 = @intCast(i);
+        try cache.put(key, @intCast(i * 10));
+        try std.testing.expectEqual(@as(usize, 1), cache.count());
+        try std.testing.expectEqual(@as(u32, @intCast(i * 10)), cache.get(key).?);
+
+        // Previous key should be gone
+        if (i > 0) {
+            try std.testing.expectEqual(@as(?u32, null), cache.get(key - 1));
+        }
+    }
+}
+
+test "put and immediately get returns correct value" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(42, 9999);
+    try std.testing.expectEqual(@as(?u32, 9999), cache.get(42));
+
+    try cache.put(0, 0);
+    try std.testing.expectEqual(@as(?u32, 0), cache.get(0));
+
+    try cache.put(std.math.maxInt(u64), std.math.maxInt(u32));
+    try std.testing.expectEqual(@as(?u32, std.math.maxInt(u32)), cache.get(std.math.maxInt(u64)));
+}
+
+test "remove non-existent key returns false" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try std.testing.expect(!cache.remove(1));
+    try std.testing.expect(!cache.remove(0));
+    try std.testing.expect(!cache.remove(std.math.maxInt(u64)));
+    try std.testing.expectEqual(@as(usize, 0), cache.count());
+}
+
+test "fill cache exactly to capacity — no eviction needed" {
+    var cache = LruCache(u32).init(std.testing.allocator, 5);
+    defer cache.deinit();
+
+    try cache.put(1, 10);
+    try cache.put(2, 20);
+    try cache.put(3, 30);
+    try cache.put(4, 40);
+    try cache.put(5, 50);
+
+    try std.testing.expectEqual(@as(usize, 5), cache.count());
+
+    // All entries should still be present
+    try std.testing.expectEqual(@as(?u32, 10), cache.get(1));
+    try std.testing.expectEqual(@as(?u32, 20), cache.get(2));
+    try std.testing.expectEqual(@as(?u32, 30), cache.get(3));
+    try std.testing.expectEqual(@as(?u32, 40), cache.get(4));
+    try std.testing.expectEqual(@as(?u32, 50), cache.get(5));
+}
+
+test "clear already-empty cache" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    // Clear when empty
+    cache.clear();
+    try std.testing.expectEqual(@as(usize, 0), cache.count());
+    try std.testing.expectEqual(@as(?u32, null), cache.get(1));
+
+    // Clear again
+    cache.clear();
+    try std.testing.expectEqual(@as(usize, 0), cache.count());
+
+    // Should still work after double clear
+    try cache.put(1, 100);
+    try std.testing.expectEqual(@as(?u32, 100), cache.get(1));
+    try std.testing.expectEqual(@as(usize, 1), cache.count());
+}
+
+test "remove then re-add same key" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(1, 100);
+    try std.testing.expect(cache.remove(1));
+    try std.testing.expectEqual(@as(?u32, null), cache.get(1));
+    try std.testing.expectEqual(@as(usize, 0), cache.count());
+
+    try cache.put(1, 200);
+    try std.testing.expectEqual(@as(?u32, 200), cache.get(1));
+    try std.testing.expectEqual(@as(usize, 1), cache.count());
+}
+
+test "put update promotes to MRU (prevents eviction)" {
+    var cache = LruCache(u32).init(std.testing.allocator, 3);
+    defer cache.deinit();
+
+    try cache.put(1, 10);
+    try cache.put(2, 20);
+    try cache.put(3, 30);
+
+    // Update key 1 — should promote it to MRU
+    try cache.put(1, 11);
+
+    // Add key 4 — should evict key 2 (now LRU), not key 1
+    try cache.put(4, 40);
+    try std.testing.expectEqual(@as(?u32, 11), cache.get(1)); // updated and promoted
+    try std.testing.expectEqual(@as(?u32, null), cache.get(2)); // evicted
+    try std.testing.expectEqual(@as(?u32, 30), cache.get(3));
+    try std.testing.expectEqual(@as(?u32, 40), cache.get(4));
+}
+
+test "remove head entry" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(1, 10);
+    try cache.put(2, 20);
+    try cache.put(3, 30); // 3 is head (MRU)
+
+    try std.testing.expect(cache.remove(3)); // remove head
+    try std.testing.expectEqual(@as(usize, 2), cache.count());
+    try std.testing.expectEqual(@as(?u32, null), cache.get(3));
+    try std.testing.expectEqual(@as(?u32, 10), cache.get(1));
+    try std.testing.expectEqual(@as(?u32, 20), cache.get(2));
+}
+
+test "remove tail entry" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(1, 10); // 1 is tail (LRU)
+    try cache.put(2, 20);
+    try cache.put(3, 30);
+
+    try std.testing.expect(cache.remove(1)); // remove tail
+    try std.testing.expectEqual(@as(usize, 2), cache.count());
+    try std.testing.expectEqual(@as(?u32, null), cache.get(1));
+    try std.testing.expectEqual(@as(?u32, 20), cache.get(2));
+    try std.testing.expectEqual(@as(?u32, 30), cache.get(3));
+}
+
+test "remove middle entry" {
+    var cache = LruCache(u32).init(std.testing.allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(1, 10);
+    try cache.put(2, 20); // middle
+    try cache.put(3, 30);
+
+    try std.testing.expect(cache.remove(2)); // remove middle
+    try std.testing.expectEqual(@as(usize, 2), cache.count());
+    try std.testing.expectEqual(@as(?u32, null), cache.get(2));
+    try std.testing.expectEqual(@as(?u32, 10), cache.get(1));
+    try std.testing.expectEqual(@as(?u32, 30), cache.get(3));
+
+    // Eviction still works after removing middle
+    try cache.put(4, 40);
+    try cache.put(5, 50);
+    try std.testing.expectEqual(@as(usize, 4), cache.count());
+}
+
+test "large number of operations stress test" {
+    var cache = LruCache(u32).init(std.testing.allocator, 10);
+    defer cache.deinit();
+
+    // Insert 100 keys into a cache of size 10
+    for (0..100) |i| {
+        try cache.put(@intCast(i), @intCast(i));
+    }
+
+    // Only last 10 should remain
+    try std.testing.expectEqual(@as(usize, 10), cache.count());
+
+    for (0..90) |i| {
+        try std.testing.expectEqual(@as(?u32, null), cache.get(@intCast(i)));
+    }
+    for (90..100) |i| {
+        try std.testing.expectEqual(@as(u32, @intCast(i)), cache.get(@intCast(i)).?);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **53 new edge case tests** across 4 storage/persistence modules: `storage.zig` (16), `wal.zig` (10), `hot_cache.zig` (13), `tier_manager.zig` (14)
- Tests cover corrupted data, truncation, capacity limits, boundary values, special characters, and rapid state transitions
- **3 production bugs discovered and fixed** during testing

## Bugs Fixed
1. **wal.zig — Panic on truncated WAL data**: The read helpers (`readU16`, `readU32`, `readU64`, `readI64`, `readBytesView`) accessed array indices without bounds checking, causing an index-out-of-bounds panic on truncated data instead of gracefully stopping replay. Now they return `error.Truncated` and `parseRecord` propagates it correctly.

2. **wal.zig — Panic on invalid WAL op byte**: `parseRecord` used `@enumFromInt(op_byte)` which panics on invalid values. Replaced with `std.meta.intToEnum` which returns an error, allowing `replay()` to gracefully stop on corrupted data.

3. **tier_manager.zig — Memory leak in `registerCold`**: When re-registering a repo with the same ID, the old entry's duped path string was not freed. Now `registerCold` checks for an existing entry and frees its resources before overwriting.

## Test plan
- [x] All 237 tests pass with `zig build test --summary all`
- [x] Zero memory leaks detected by `std.testing.allocator`
- [x] Tests cover: empty inputs, max-value boundaries, truncated/corrupted data, special characters (unicode, null bytes), all enum variants, stress/cycling patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)