### PR TITLE
test: edge case tests for core graph modules

### DIFF
--- a/src/graph/graph.zig
+++ b/src/graph/graph.zig
@@ -285,3 +285,278 @@ test "empty graph queries return null/empty/zero" {
     try std.testing.expectEqual(@as(usize, 0), g.symbolCount());
     try std.testing.expectEqual(@as(usize, 0), g.edgeCount());
 }
+
+// ── Edge case tests ─────────────────────────────────────────────────────────
+
+test "add edge to nonexistent nodes — no symbols required" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    // Edges can exist between node IDs that have no corresponding Symbol entry
+    try g.addEdge(.{ .src = 100, .dst = 200, .kind = .calls });
+    try std.testing.expectEqual(@as(usize, 1), g.edgeCount());
+    try std.testing.expectEqual(@as(usize, 1), g.outDegree(100));
+    // But the symbols themselves don't exist
+    try std.testing.expectEqual(@as(?Symbol, null), g.getSymbol(100));
+    try std.testing.expectEqual(@as(?Symbol, null), g.getSymbol(200));
+}
+
+test "self-loop edge — src equals dst" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 1, .kind = .references });
+
+    // out_edges[1] and in_edges[1] should both contain the same edge
+    const out = g.outEdges(1);
+    const in = g.inEdges(1);
+    try std.testing.expectEqual(@as(usize, 1), out.len);
+    try std.testing.expectEqual(@as(usize, 1), in.len);
+    try std.testing.expectEqual(@as(u64, 1), out[0].src);
+    try std.testing.expectEqual(@as(u64, 1), out[0].dst);
+    try std.testing.expectEqual(@as(u64, 1), in[0].src);
+    try std.testing.expectEqual(@as(u64, 1), in[0].dst);
+    try std.testing.expectEqual(@as(usize, 1), g.edgeCount());
+}
+
+test "multiple edges between same nodes with different kinds" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .references });
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .imports });
+
+    try std.testing.expectEqual(@as(usize, 3), g.outDegree(1));
+    try std.testing.expectEqual(@as(usize, 3), g.edgeCount());
+
+    const out = g.outEdges(1);
+    try std.testing.expectEqual(EdgeKind.calls, out[0].kind);
+    try std.testing.expectEqual(EdgeKind.references, out[1].kind);
+    try std.testing.expectEqual(EdgeKind.imports, out[2].kind);
+}
+
+test "duplicate edges (same src, dst, kind) accumulate" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls, .weight = 1.0 });
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls, .weight = 2.0 });
+
+    // Both edges are stored (addEdge does not deduplicate)
+    try std.testing.expectEqual(@as(usize, 2), g.outDegree(1));
+    try std.testing.expectEqual(@as(usize, 2), g.edgeCount());
+}
+
+test "very large symbol ID — u64 max" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    const max_id = std.math.maxInt(u64);
+    try g.addSymbol(.{ .id = max_id, .name = "max_sym", .kind = .constant, .file_id = 0, .line = 0, .col = 0, .scope = "" });
+
+    const sym = g.getSymbol(max_id).?;
+    try std.testing.expectEqualStrings("max_sym", sym.name);
+    try std.testing.expectEqual(max_id, sym.id);
+}
+
+test "symbol with id zero" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addSymbol(.{ .id = 0, .name = "zero", .kind = .function, .file_id = 0, .line = 0, .col = 0, .scope = "" });
+
+    const sym = g.getSymbol(0).?;
+    try std.testing.expectEqualStrings("zero", sym.name);
+    try std.testing.expectEqual(@as(u64, 0), sym.id);
+}
+
+test "add many symbols (150) and verify count" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    for (0..150) |i| {
+        try g.addSymbol(.{
+            .id = @intCast(i),
+            .name = "sym",
+            .kind = .function,
+            .file_id = 0,
+            .line = @intCast(i),
+            .col = 0,
+            .scope = "",
+        });
+    }
+
+    try std.testing.expectEqual(@as(usize, 150), g.symbolCount());
+
+    // Spot-check a few
+    try std.testing.expect(g.getSymbol(0) != null);
+    try std.testing.expect(g.getSymbol(74) != null);
+    try std.testing.expect(g.getSymbol(149) != null);
+    try std.testing.expect(g.getSymbol(150) == null);
+}
+
+test "add many edges (200) and verify count" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    for (0..200) |i| {
+        try g.addEdge(.{
+            .src = @intCast(i),
+            .dst = @as(u64, @intCast(i)) + 1,
+            .kind = .calls,
+        });
+    }
+
+    try std.testing.expectEqual(@as(usize, 200), g.edgeCount());
+}
+
+test "overwrite symbol preserves new data completely" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addSymbol(.{ .id = 5, .name = "original", .kind = .function, .file_id = 1, .line = 10, .col = 5, .scope = "mod_a" });
+    try g.addSymbol(.{ .id = 5, .name = "replaced", .kind = .class, .file_id = 2, .line = 20, .col = 10, .scope = "mod_b" });
+
+    const sym = g.getSymbol(5).?;
+    try std.testing.expectEqualStrings("replaced", sym.name);
+    try std.testing.expectEqual(SymbolKind.class, sym.kind);
+    try std.testing.expectEqual(@as(u32, 2), sym.file_id);
+    try std.testing.expectEqual(@as(u32, 20), sym.line);
+    try std.testing.expectEqual(@as(u16, 10), sym.col);
+    try std.testing.expectEqualStrings("mod_b", sym.scope);
+}
+
+test "symbol with empty name and scope" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addSymbol(.{ .id = 1, .name = "", .kind = .variable, .file_id = 0, .line = 0, .col = 0, .scope = "" });
+
+    const sym = g.getSymbol(1).?;
+    try std.testing.expectEqualStrings("", sym.name);
+    try std.testing.expectEqualStrings("", sym.scope);
+}
+
+test "file with empty path" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addFile(.{ .id = 1, .path = "", .language = .unknown, .last_modified = 0, .hash = [_]u8{0} ** 32 });
+
+    const f = g.getFile(1).?;
+    try std.testing.expectEqualStrings("", f.path);
+}
+
+test "commit with empty author and message" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addCommit(.{ .id = 1, .hash = [_]u8{'0'} ** 40, .timestamp = 0, .author = "", .message = "" });
+
+    const c = g.getCommit(1).?;
+    try std.testing.expectEqualStrings("", c.author);
+    try std.testing.expectEqualStrings("", c.message);
+}
+
+test "overwrite file preserves new data" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addFile(.{ .id = 1, .path = "old.zig", .language = .zig, .last_modified = 100, .hash = [_]u8{0} ** 32 });
+    try g.addFile(.{ .id = 1, .path = "new.ts", .language = .typescript, .last_modified = 200, .hash = [_]u8{1} ** 32 });
+
+    const f = g.getFile(1).?;
+    try std.testing.expectEqualStrings("new.ts", f.path);
+    try std.testing.expectEqual(Language.typescript, f.language);
+    try std.testing.expectEqual(@as(i64, 200), f.last_modified);
+}
+
+test "overwrite commit preserves new data" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addCommit(.{ .id = 1, .hash = [_]u8{'a'} ** 40, .timestamp = 100, .author = "alice", .message = "first" });
+    try g.addCommit(.{ .id = 1, .hash = [_]u8{'b'} ** 40, .timestamp = 200, .author = "bob", .message = "second" });
+
+    const c = g.getCommit(1).?;
+    try std.testing.expectEqualStrings("bob", c.author);
+    try std.testing.expectEqualStrings("second", c.message);
+    try std.testing.expectEqual(@as(i64, 200), c.timestamp);
+}
+
+test "edges with max u64 node IDs" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    const max = std.math.maxInt(u64);
+    try g.addEdge(.{ .src = max, .dst = max - 1, .kind = .calls });
+
+    try std.testing.expectEqual(@as(usize, 1), g.outDegree(max));
+    const out = g.outEdges(max);
+    try std.testing.expectEqual(max - 1, out[0].dst);
+}
+
+test "inEdges returns empty for node with only out-edges" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+
+    // Node 1 has out-edges but no in-edges
+    try std.testing.expectEqual(@as(usize, 0), g.inEdges(1).len);
+    // Node 2 has in-edges but no out-edges
+    try std.testing.expectEqual(@as(usize, 0), g.outEdges(2).len);
+}
+
+test "edge with zero weight" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls, .weight = 0.0 });
+
+    const out = g.outEdges(1);
+    try std.testing.expectEqual(@as(f32, 0.0), out[0].weight);
+}
+
+test "edge with negative weight" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls, .weight = -5.0 });
+
+    const out = g.outEdges(1);
+    try std.testing.expectEqual(@as(f32, -5.0), out[0].weight);
+}
+
+test "graph with chain topology — verify traversal" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    // Chain: 1 → 2 → 3 → 4 → 5
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+    try g.addEdge(.{ .src = 2, .dst = 3, .kind = .calls });
+    try g.addEdge(.{ .src = 3, .dst = 4, .kind = .calls });
+    try g.addEdge(.{ .src = 4, .dst = 5, .kind = .calls });
+
+    try std.testing.expectEqual(@as(usize, 4), g.edgeCount());
+    try std.testing.expectEqual(@as(usize, 1), g.outDegree(1));
+    try std.testing.expectEqual(@as(usize, 1), g.outDegree(4));
+    try std.testing.expectEqual(@as(usize, 0), g.outDegree(5)); // terminal
+    try std.testing.expectEqual(@as(usize, 0), g.inEdges(1).len); // root
+    try std.testing.expectEqual(@as(usize, 1), g.inEdges(5).len); // terminal has one in-edge
+}
+
+test "bidirectional edges between two nodes" {
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+    try g.addEdge(.{ .src = 2, .dst = 1, .kind = .calls });
+
+    try std.testing.expectEqual(@as(usize, 1), g.outDegree(1));
+    try std.testing.expectEqual(@as(usize, 1), g.outDegree(2));
+    try std.testing.expectEqual(@as(usize, 1), g.inEdges(1).len);
+    try std.testing.expectEqual(@as(usize, 1), g.inEdges(2).len);
+    try std.testing.expectEqual(@as(usize, 2), g.edgeCount());
+}

--- a/src/graph/types.zig
+++ b/src/graph/types.zig
@@ -111,3 +111,224 @@ test "struct sizes are reasonable" {
     // File should be under 96 bytes
     try std.testing.expect(@sizeOf(File) <= 96);
 }
+
+// ── Edge case tests ─────────────────────────────────────────────────────────
+
+test "SymbolKind all values are distinct" {
+    const kinds = [_]SymbolKind{ .function, .method, .class, .variable, .constant, .type_def, .interface, .module };
+    for (kinds, 0..) |a, i| {
+        for (kinds, 0..) |b, j| {
+            if (i != j) {
+                try std.testing.expect(@intFromEnum(a) != @intFromEnum(b));
+            }
+        }
+    }
+}
+
+test "SymbolKind enum count is 8" {
+    const fields = @typeInfo(SymbolKind).@"enum".fields;
+    try std.testing.expectEqual(@as(usize, 8), fields.len);
+}
+
+test "EdgeKind all values are distinct" {
+    const kinds = [_]EdgeKind{ .calls, .imports, .defines, .modifies, .references };
+    for (kinds, 0..) |a, i| {
+        for (kinds, 0..) |b, j| {
+            if (i != j) {
+                try std.testing.expect(@intFromEnum(a) != @intFromEnum(b));
+            }
+        }
+    }
+}
+
+test "EdgeKind enum count is 5" {
+    const fields = @typeInfo(EdgeKind).@"enum".fields;
+    try std.testing.expectEqual(@as(usize, 5), fields.len);
+}
+
+test "Language enum count is 5" {
+    const fields = @typeInfo(Language).@"enum".fields;
+    try std.testing.expectEqual(@as(usize, 5), fields.len);
+}
+
+test "Symbol with zero id" {
+    const sym = Symbol{
+        .id = 0,
+        .name = "zero",
+        .kind = .function,
+        .file_id = 0,
+        .line = 0,
+        .col = 0,
+        .scope = "",
+    };
+    try std.testing.expectEqual(@as(u64, 0), sym.id);
+    try std.testing.expectEqualStrings("zero", sym.name);
+}
+
+test "Symbol with max u64 id" {
+    const sym = Symbol{
+        .id = std.math.maxInt(u64),
+        .name = "max",
+        .kind = .module,
+        .file_id = std.math.maxInt(u32),
+        .line = std.math.maxInt(u32),
+        .col = std.math.maxInt(u16),
+        .scope = "deep.nested.scope",
+    };
+    try std.testing.expectEqual(std.math.maxInt(u64), sym.id);
+    try std.testing.expectEqual(std.math.maxInt(u32), sym.file_id);
+    try std.testing.expectEqual(std.math.maxInt(u32), sym.line);
+    try std.testing.expectEqual(std.math.maxInt(u16), sym.col);
+}
+
+test "Symbol with empty name and scope" {
+    const sym = Symbol{
+        .id = 1,
+        .name = "",
+        .kind = .variable,
+        .file_id = 0,
+        .line = 0,
+        .col = 0,
+        .scope = "",
+    };
+    try std.testing.expectEqual(@as(usize, 0), sym.name.len);
+    try std.testing.expectEqual(@as(usize, 0), sym.scope.len);
+}
+
+test "File with empty path" {
+    const f = File{
+        .id = 0,
+        .path = "",
+        .language = .unknown,
+        .last_modified = 0,
+        .hash = [_]u8{0} ** 32,
+    };
+    try std.testing.expectEqual(@as(usize, 0), f.path.len);
+    try std.testing.expectEqual(Language.unknown, f.language);
+}
+
+test "File with max values" {
+    const f = File{
+        .id = std.math.maxInt(u32),
+        .path = "a" ** 256,
+        .language = .python,
+        .last_modified = std.math.maxInt(i64),
+        .hash = [_]u8{0xFF} ** 32,
+    };
+    try std.testing.expectEqual(std.math.maxInt(u32), f.id);
+    try std.testing.expectEqual(@as(usize, 256), f.path.len);
+    try std.testing.expectEqual(std.math.maxInt(i64), f.last_modified);
+    try std.testing.expectEqual(@as(u8, 0xFF), f.hash[31]);
+}
+
+test "File with negative timestamp" {
+    const f = File{
+        .id = 1,
+        .path = "old.zig",
+        .language = .zig,
+        .last_modified = -1_000_000,
+        .hash = [_]u8{0} ** 32,
+    };
+    try std.testing.expect(f.last_modified < 0);
+}
+
+test "Edge with weight zero" {
+    const e = Edge{ .src = 1, .dst = 2, .kind = .calls, .weight = 0.0 };
+    try std.testing.expectEqual(@as(f32, 0.0), e.weight);
+}
+
+test "Edge with negative weight" {
+    const e = Edge{ .src = 1, .dst = 2, .kind = .calls, .weight = -1.0 };
+    try std.testing.expectEqual(@as(f32, -1.0), e.weight);
+}
+
+test "Edge with very large weight" {
+    const e = Edge{ .src = 1, .dst = 2, .kind = .calls, .weight = std.math.floatMax(f32) };
+    try std.testing.expectEqual(std.math.floatMax(f32), e.weight);
+}
+
+test "Edge with infinity weight" {
+    const e = Edge{ .src = 1, .dst = 2, .kind = .calls, .weight = std.math.inf(f32) };
+    try std.testing.expect(std.math.isInf(e.weight));
+}
+
+test "Edge with NaN weight" {
+    const e = Edge{ .src = 1, .dst = 2, .kind = .calls, .weight = std.math.nan(f32) };
+    try std.testing.expect(std.math.isNan(e.weight));
+}
+
+test "Edge with max u64 src and dst" {
+    const e = Edge{
+        .src = std.math.maxInt(u64),
+        .dst = std.math.maxInt(u64),
+        .kind = .references,
+        .weight = 0.5,
+    };
+    try std.testing.expectEqual(std.math.maxInt(u64), e.src);
+    try std.testing.expectEqual(std.math.maxInt(u64), e.dst);
+}
+
+test "Edge self-loop (src == dst)" {
+    const e = Edge{ .src = 42, .dst = 42, .kind = .references };
+    try std.testing.expectEqual(e.src, e.dst);
+    try std.testing.expectEqual(@as(f32, 1.0), e.weight);
+}
+
+test "Commit with empty author and message" {
+    const c = Commit{
+        .id = 0,
+        .hash = [_]u8{'0'} ** 40,
+        .timestamp = 0,
+        .author = "",
+        .message = "",
+    };
+    try std.testing.expectEqual(@as(usize, 0), c.author.len);
+    try std.testing.expectEqual(@as(usize, 0), c.message.len);
+}
+
+test "Commit with negative timestamp" {
+    const c = Commit{
+        .id = 1,
+        .hash = [_]u8{'a'} ** 40,
+        .timestamp = -1,
+        .author = "ancient",
+        .message = "before epoch",
+    };
+    try std.testing.expect(c.timestamp < 0);
+}
+
+test "Commit with max id" {
+    const c = Commit{
+        .id = std.math.maxInt(u32),
+        .hash = [_]u8{'f'} ** 40,
+        .timestamp = std.math.maxInt(i64),
+        .author = "max",
+        .message = "max commit",
+    };
+    try std.testing.expectEqual(std.math.maxInt(u32), c.id);
+    try std.testing.expectEqual(std.math.maxInt(i64), c.timestamp);
+}
+
+test "all EdgeKind values can be used in Edge struct" {
+    const kinds = [_]EdgeKind{ .calls, .imports, .defines, .modifies, .references };
+    for (kinds) |k| {
+        const e = Edge{ .src = 1, .dst = 2, .kind = k };
+        try std.testing.expectEqual(k, e.kind);
+    }
+}
+
+test "all SymbolKind values can be used in Symbol struct" {
+    const kinds = [_]SymbolKind{ .function, .method, .class, .variable, .constant, .type_def, .interface, .module };
+    for (kinds) |k| {
+        const sym = Symbol{ .id = 1, .name = "x", .kind = k, .file_id = 0, .line = 0, .col = 0, .scope = "" };
+        try std.testing.expectEqual(k, sym.kind);
+    }
+}
+
+test "all Language values can be used in File struct" {
+    const langs = [_]Language{ .typescript, .javascript, .zig, .python, .unknown };
+    for (langs) |l| {
+        const f = File{ .id = 0, .path = "test", .language = l, .last_modified = 0, .hash = [_]u8{0} ** 32 };
+        try std.testing.expectEqual(l, f.language);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **82 new edge case tests** across the 4 core graph modules (`types.zig`, `graph.zig`, `edge_weights.zig`, `ppr.zig`)
- **Fixes a bug in `pprPush`** where self-loop edges lost their distributed residual because `r[u]` was zeroed *after* distributing to neighbours (including self). Moved the zeroing before distribution so self-loop shares accumulate correctly.

### Tests added by module

| Module | New tests | Coverage areas |
|--------|-----------|----------------|
| `types.zig` | 24 | Enum distinctness/counts, zero/max u64 IDs, empty strings, negative/infinity/NaN weights, edge self-loops, commit boundary values |
| `graph.zig` | 20 | Edges to nonexistent nodes, self-loop edges, multiple edge kinds between same nodes, duplicate edges, u64 max IDs, 150+ symbols, empty strings, overwrite semantics, chain topology, bidirectional edges |
| `edge_weights.zig` | 23 | Very large/small time diffs, future timestamps, zero/max frequency, depth clamping, modifiesWeight edge cases, normaliseOutEdges with single/many/mixed-zero/very-large/very-small weights, Stanton condition boundaries, monotonic decay verification |
| `ppr.zig` | 15 | Self-loops, alpha=0/1, very small epsilon, disconnected components, topK with k=0/empty/exclude-all, score non-negativity, weighted proportional distribution, chain distance decay, constants verification |

### Bug found and fixed

**`pprPush` self-loop residual loss** (`src/graph/ppr.zig`): In the push loop, `r[u] = 0` was executed *after* distributing residual to out-neighbours. When a node had a self-loop (edge from u to u), the share distributed to `r[u]` via the self-loop was immediately wiped out by the subsequent zeroing. The fix moves `r[u] = 0` before the distribution loop, matching the standard Andersen-Chung-Lang push algorithm specification.

## Test plan
- [x] All 266 tests pass (`zig build test --summary all`)
- [x] No memory leaks detected by `std.testing.allocator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)