### PR TITLE
fix: resolve swarm review issues #115–#124 (7 bugs fixed)

### DIFF
--- a/src/auth.zig
+++ b/src/auth.zig
@@ -164,7 +164,7 @@ fn checkTrial(alloc: std.mem.Allocator) AuthResult {
     // Parse started_at from JSON
     const started_at = parseStartedAt(content) orelse return noAuth();
     const now = std.time.timestamp();
-    const elapsed_days = @divTrunc(now - started_at, 86400);
+    const elapsed_days = @divTrunc(@max(now - started_at, 0), 86400);
     const remaining = TRIAL_DAYS - elapsed_days;
 
     if (remaining > 0) {

--- a/src/graph/harness.zig
+++ b/src/graph/harness.zig
@@ -30,6 +30,7 @@ pub const Harness = struct {
     mode: QueryMode,
     socket_fd: ?std.posix.fd_t,
     graph_path: []const u8,
+    socket_path: []const u8,
     alloc: std.mem.Allocator,
 
     /// Initialize a new harness. Detects whether daemon mode is available
@@ -48,6 +49,7 @@ pub const Harness = struct {
             .mode = .local,
             .socket_fd = null,
             .graph_path = graph_path,
+            .socket_path = socket_path,
             .alloc = alloc,
         };
 
@@ -87,7 +89,7 @@ pub const Harness = struct {
         if (self.socket_fd != null) return true;
 
         // Attempt reconnection
-        const stream = std.net.connectUnixSocket(DAEMON_SOCKET_PATH) catch return false;
+        const stream = std.net.connectUnixSocket(self.socket_path) catch return false;
         self.socket_fd = stream.handle;
         return true;
     }
@@ -479,6 +481,7 @@ test "detectMode returns local when socket does not exist" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -492,6 +495,7 @@ test "fallbackToLocal switches mode" {
         .mode = .daemon,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
 
@@ -552,6 +556,7 @@ test "querySymbolAt returns error when no graph file" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = "nonexistent/graph.bin",
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -565,6 +570,7 @@ test "queryCallers returns error when no graph file" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = "nonexistent/graph.bin",
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -578,6 +584,7 @@ test "queryCallees returns error when no graph file" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = "nonexistent/graph.bin",
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -591,6 +598,7 @@ test "queryDependents returns error when no graph file" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = "nonexistent/graph.bin",
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -613,6 +621,7 @@ test "local query with in-memory graph via dispatchLocal" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -647,6 +656,7 @@ test "dispatchLocal returns error for invalid JSON" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -663,6 +673,7 @@ test "dispatchLocal returns error for unknown method" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -676,6 +687,7 @@ test "getMode returns current mode" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
 
@@ -692,6 +704,7 @@ test "dispatchLocal with missing params returns MissingParams" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -721,6 +734,7 @@ test "dispatchLocal shutdown returns ShutdownRequested" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -737,6 +751,7 @@ test "dispatchLocal with empty JSON object returns InvalidRequest" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -754,6 +769,7 @@ test "dispatchLocal with array JSON returns InvalidRequest" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -770,6 +786,7 @@ test "dispatchLocal symbol_at on empty graph returns empty symbols" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -788,6 +805,7 @@ test "dispatchLocal find_callers on empty graph returns empty results" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -806,6 +824,7 @@ test "dispatchLocal find_callees on empty graph returns empty results" {
         .mode = .local,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -821,6 +840,7 @@ test "mode detection with nonexistent socket path defaults to local" {
         .mode = .daemon,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
     defer h.deinit();
@@ -834,6 +854,7 @@ test "fallbackToLocal from daemon with null socket_fd" {
         .mode = .daemon,
         .socket_fd = null,
         .graph_path = GRAPH_PATH,
+        .socket_path = DAEMON_SOCKET_PATH,
         .alloc = std.testing.allocator,
     };
 

--- a/src/graph/ingest.zig
+++ b/src/graph/ingest.zig
@@ -170,7 +170,6 @@ pub const Ingester = struct {
 
     fn addSymbol(self: *Ingester, name: []const u8, kind: SymbolKind, file_id: u32, line: u32, scope: []const u8) !void {
         const id = self.next_symbol_id;
-        self.next_symbol_id += 1;
         try self.graph.addSymbol(.{
             .id = id,
             .name = name,
@@ -180,6 +179,7 @@ pub const Ingester = struct {
             .col = 0,
             .scope = scope,
         });
+        self.next_symbol_id += 1;
     }
 };
 

--- a/src/graph/storage.zig
+++ b/src/graph/storage.zig
@@ -109,7 +109,7 @@ pub fn deserialize(reader: anytype, alloc: std.mem.Allocator) !CodeGraph {
         const id = try reader.readInt(u64, .little);
         const name = try readBytes(reader, alloc);
         defer alloc.free(name);
-        const kind: SymbolKind = @enumFromInt(try reader.readByte());
+        const kind: SymbolKind = std.meta.intToEnum(SymbolKind, try reader.readByte()) catch return error.InvalidFormat;
         const file_id = try reader.readInt(u32, .little);
         const line = try reader.readInt(u32, .little);
         const col = try reader.readInt(u16, .little);
@@ -132,7 +132,7 @@ pub fn deserialize(reader: anytype, alloc: std.mem.Allocator) !CodeGraph {
         const id = try reader.readInt(u32, .little);
         const path = try readBytes(reader, alloc);
         defer alloc.free(path);
-        const language: Language = @enumFromInt(try reader.readByte());
+        const language: Language = std.meta.intToEnum(Language, try reader.readByte()) catch return error.InvalidFormat;
         const last_modified = try reader.readInt(i64, .little);
         var hash: [32]u8 = undefined;
         try reader.readNoEof(&hash);
@@ -170,7 +170,7 @@ pub fn deserialize(reader: anytype, alloc: std.mem.Allocator) !CodeGraph {
     for (0..num_edges) |_| {
         const src = try reader.readInt(u64, .little);
         const dst = try reader.readInt(u64, .little);
-        const kind: EdgeKind = @enumFromInt(try reader.readByte());
+        const kind: EdgeKind = std.meta.intToEnum(EdgeKind, try reader.readByte()) catch return error.InvalidFormat;
         var weight_bytes: [4]u8 = undefined;
         try reader.readNoEof(&weight_bytes);
         const weight: f32 = @bitCast(weight_bytes);

--- a/src/graph/wal.zig
+++ b/src/graph/wal.zig
@@ -257,7 +257,7 @@ fn parseRecord(data: []const u8, start: usize, op_byte: u8) !ParseResult {
             const id = try readU64(data, &pos);
             const name = try readBytesView(data, &pos);
             if (pos >= data.len) return error.Truncated;
-            const kind: SymbolKind = @enumFromInt(data[pos]);
+            const kind: SymbolKind = std.meta.intToEnum(SymbolKind, data[pos]) catch return error.InvalidOp;
             pos += 1;
             const file_id = try readU32(data, &pos);
             const line = try readU32(data, &pos);

--- a/src/main.zig
+++ b/src/main.zig
@@ -227,13 +227,13 @@ fn writeResult(
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(alloc);
 
-    buf.appendSlice(alloc, "{\"jsonrpc\":\"2.0\",\"id\":") catch return;
+    buf.appendSlice(alloc, "{\"jsonrpc\":\"2.0\",\"id\":") catch return writeStaticError(stdout);
     appendId(alloc, &buf, id);
-    buf.appendSlice(alloc, ",\"result\":") catch return;
+    buf.appendSlice(alloc, ",\"result\":") catch return writeStaticError(stdout);
     for (result) |c| {
-        if (c != '\n' and c != '\r') buf.append(alloc, c) catch return;
+        if (c != '\n' and c != '\r') buf.append(alloc, c) catch return writeStaticError(stdout);
     }
-    buf.appendSlice(alloc, "}\n") catch return;
+    buf.appendSlice(alloc, "}\n") catch return writeStaticError(stdout);
     stdout.writeAll(buf.items) catch {};
 }
 


### PR DESCRIPTION
## Summary

Fixes 7 of the 14 bugs found by the `run_swarm` broad code review. Applied via writable swarm agents (5 parallel Codex instances) + manual compile-error cleanup.

| Issue | File | Fix |
|---|---|---|
| #115 | `storage.zig`, `wal.zig` | `@enumFromInt` → `std.meta.intToEnum` with error on invalid bytes |
| #116 | `gh.zig` | Synchronous fallback drain when `Thread.spawn` fails (deadlock prevention) |
| #117 | `main.zig` | `writeResult` `catch return` → `catch return writeStaticError(stdout)` |
| #118 | `wal.zig` | `crc_start` moved from namespace global to per-instance field (previous commit) |
| #120 | `ingest.zig` | `next_symbol_id` incremented only after successful insertion |
| #121 | `harness.zig` | `socket_path` stored as instance field; `ensureConnection` uses it |
| #122 | `cache.zig` | Milestone prefetch added; `invalidate()` clears milestones too |
| #124 | `auth.zig` | Saturating subtraction guards against clock skew in `checkTrial` |

Also includes:
- `codex_appserver.zig`: `SandboxPolicy` enum + `runTurnPolicy()` for writable agents
- `swarm.zig` / `tools.zig`: `run_swarm` gains `writable: bool` flag

## Not addressed yet (need separate PRs)
- #119 ppr_incremental allocator propagation (API change required)
- #123 search.zig error classification (low severity)
- #125–#128 perf + refactor + tests