### PR TITLE
feat: dynamic repo detection + close_issues_batch (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+**/.DS_Store
 .zig-cache/
 zig-out/
 .mcp-e2e-test

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,8 +130,9 @@ fn run(alloc: std.mem.Allocator) void {
             handleInitialize(alloc, stdout, id);
         } else if (mj.eql(method, "notifications/initialized")) {
             // Warm the session cache now that the client is ready.
-            // Runs gh label list + milestones — 2 calls, <500ms.
+            // Also detect the current repo slug from the CWD git remote.
             cache.prefetch(alloc);
+            tools.detectAndUpdateRepo(alloc);
         } else if (mj.eql(method, "tools/list")) {
             writeResult(alloc, stdout, id, tools.tools_list);
         } else if (mj.eql(method, "tools/call")) {


### PR DESCRIPTION
## Summary

- **Fix #114 — Dynamic repo**: Replace hardcoded `DEFAULT_REPO = "justrach/codedb"` with a runtime-detected global. `detectAndUpdateRepo()` calls `gh repo view --json nameWithOwner` from the CWD and updates all `--repo` flags automatically. Called on MCP `notifications/initialized` and inside `set_repo` after every `chdir`, so gitagent works correctly with any repo without restart.
- **New `close_issues_batch` tool**: Close multiple issues in one call instead of N sequential `close_issue` invocations. Accepts `issue_numbers: [103, 104, 105]` (+ optional `pr_number`) and returns a JSON array of per-issue results.
- **Fix duplicate dispatch**: Removed duplicate `.close_issue` switch arm introduced during refactor.

## Test plan

- [ ] Start gitagent-mcp against a different repo, verify `--repo` picks up the correct `owner/repo` on `notifications/initialized`
- [ ] Call `set_repo` with a different path, verify subsequent `get_project_state` hits the new repo
- [ ] Call `close_issues_batch` with `{"issue_numbers": [N, M]}` and confirm both issues close with `status:done`
- [ ] `zig build` passes (verified locally)

Closes #114