### PR TITLE
fix: auto-compact on ContextWindowExceeded + correct sandboxPolicy type (#161)

### DIFF
--- a/src/codex_appserver.zig
+++ b/src/codex_appserver.zig
@@ -173,9 +173,11 @@ fn runTurn_(
 
     // ── 3. thread/start ────────────────────────────────────────────────────
     {
+        // "dangerFullAccess" is the correct type for unrestricted agents.
+        // approvalPolicy:"never" suppresses all approval prompts.
         const policy_json: []const u8 = switch (policy) {
             .read_only => "{\"type\":\"readOnly\"}",
-            .writable  => "{\"type\":\"unrestricted\"}",
+            .writable  => "{\"type\":\"dangerFullAccess\"}",
         };
         var msg: std.ArrayList(u8) = .empty;
         defer msg.deinit(alloc);
@@ -213,8 +215,48 @@ fn runTurn_(
         };
     }
 
-    // ── 5. Stream until turn/completed ────────────────────────────────────
-    streamTurn(alloc, proc_out, out);
+    // ── 5. Stream; auto-compact and retry once on ContextWindowExceeded ───
+    if (!streamTurn(alloc, proc_out, out)) return;
+
+    // Context window exceeded: clear partial output, compact, retry once.
+    out.clearRetainingCapacity();
+
+    // thread/compact/start — returns {} immediately; compaction streams as turn events
+    {
+        var msg: std.ArrayList(u8) = .empty;
+        defer msg.deinit(alloc);
+        msg.appendSlice(alloc,
+            \\{"method":"thread/compact/start","id":3,"params":{"threadId":"
+        ) catch return;
+        mj.writeEscaped(alloc, &msg, thread_id);
+        msg.appendSlice(alloc, "\"}}") catch return;
+        writeMsgSlice(proc_in, msg.items) catch {
+            appendErr(alloc, out, "write thread/compact/start failed"); return;
+        };
+    }
+
+    // Drain the compaction turn (discard its output)
+    var discard: std.ArrayList(u8) = .empty;
+    defer discard.deinit(alloc);
+    _ = streamTurn(alloc, proc_out, &discard);
+
+    // Retry the original turn (id:4; don't recurse on a second failure)
+    {
+        var msg: std.ArrayList(u8) = .empty;
+        defer msg.deinit(alloc);
+        msg.appendSlice(alloc,
+            \\{"method":"turn/start","id":4,"params":{"threadId":"
+        ) catch return;
+        mj.writeEscaped(alloc, &msg, thread_id);
+        msg.appendSlice(alloc, "\",\"input\":[{\"type\":\"text\",\"text\":\"") catch return;
+        mj.writeEscaped(alloc, &msg, prompt);
+        msg.appendSlice(alloc, "\"}]}}") catch return;
+        writeMsgSlice(proc_in, msg.items) catch {
+            appendErr(alloc, out, "write retry turn/start failed"); return;
+        };
+    }
+
+    _ = streamTurn(alloc, proc_out, out);
 }
 
 // ── Wire helpers ──────────────────────────────────────────────────────────────
@@ -284,9 +326,11 @@ fn readThreadId(alloc: std.mem.Allocator, rd: anytype) ?[]u8 {
     }
 }
 
-fn streamTurn(alloc: std.mem.Allocator, rd: anytype, out: *std.ArrayList(u8)) void {
+// Returns true if the turn failed due to ContextWindowExceeded — caller should
+// compact the thread and retry. Returns false for all other outcomes (ok or error).
+fn streamTurn(alloc: std.mem.Allocator, rd: anytype, out: *std.ArrayList(u8)) bool {
     while (true) {
-        const line = readLineAlloc(alloc, rd) orelse return;
+        const line = readLineAlloc(alloc, rd) orelse return false;
         defer alloc.free(line);
         const p = std.json.parseFromSlice(std.json.Value, alloc, line, .{}) catch continue;
         defer p.deinit();
@@ -306,21 +350,37 @@ fn streamTurn(alloc: std.mem.Allocator, rd: anytype, out: *std.ArrayList(u8)) vo
         }
 
         if (std.mem.eql(u8, method, "turn/completed")) {
-            const params = obj.get("params") orelse return;
-            if (params != .object) return;
-            const turn   = params.object.get("turn")   orelse return;
-            if (turn != .object) return;
-            const status = turn.object.get("status")   orelse return;
+            const params = obj.get("params") orelse return false;
+            if (params != .object) return false;
+            const turn   = params.object.get("turn")   orelse return false;
+            if (turn != .object) return false;
+            const status = turn.object.get("status")   orelse return false;
             if (status == .string and std.mem.eql(u8, status.string, "failed")) {
                 if (turn.object.get("error")) |err_v| {
                     if (err_v == .object) {
+                        // Canonical check: codexErrorInfo field
+                        if (err_v.object.get("codexErrorInfo")) |info_v| {
+                            if (info_v == .string and
+                                std.mem.eql(u8, info_v.string, "ContextWindowExceeded"))
+                            {
+                                return true; // signal caller to compact+retry
+                            }
+                        }
+                        // Fallback: message substring (older server versions)
                         if (err_v.object.get("message")) |msg_v| {
-                            if (msg_v == .string) appendErr(alloc, out, msg_v.string);
+                            if (msg_v == .string) {
+                                if (std.mem.indexOf(u8, msg_v.string, "context window") != null or
+                                    std.mem.indexOf(u8, msg_v.string, "context length") != null)
+                                {
+                                    return true;
+                                }
+                                appendErr(alloc, out, msg_v.string);
+                            }
                         }
                     }
                 }
             }
-            return;
+            return false;
         }
     }
 }
@@ -331,4 +391,168 @@ fn appendErr(alloc: std.mem.Allocator, out: *std.ArrayList(u8), msg: []const u8)
     out.appendSlice(alloc, "{\"error\":\"") catch return;
     mj.writeEscaped(alloc, out, msg);
     out.appendSlice(alloc, "\"}") catch {};
+}
+
+// ── Tests: process adapter internals (#128) ───────────────────────────────────
+
+test "appserver: toolsBinDir does not crash and returns a string" {
+    const dir = toolsBinDir();
+    // Either empty (codex not found) or a non-empty path — never panics
+    _ = dir.len;
+}
+
+test "appserver: readLineAlloc reads up to newline, strips newline" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("hello world\n");
+writer.close();
+
+    const line = readLineAlloc(alloc, reader) orelse return error.TestExpectedLine;
+    defer alloc.free(line);
+    try std.testing.expectEqualStrings("hello world", line);
+}
+
+test "appserver: readLineAlloc returns null on immediate EOF" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    std.posix.close(fds[1]); // EOF immediately
+
+    const reader = std.fs.File{ .handle = fds[0] };
+    const line = readLineAlloc(alloc, reader);
+    try std.testing.expectEqual(@as(?[]u8, null), line);
+}
+
+test "appserver: readLineAlloc returns partial content on EOF without newline" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("no-newline");
+writer.close();
+
+    const line = readLineAlloc(alloc, reader) orelse return error.TestExpectedLine;
+    defer alloc.free(line);
+    try std.testing.expectEqualStrings("no-newline", line);
+}
+
+test "appserver: drainUntilId finds target id after skipping earlier ids" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("{\"id\":0,\"result\":{}}\n");
+    try writer.writeAll("{\"id\":1,\"result\":{}}\n");
+    try writer.writeAll("{\"id\":5,\"result\":{}}\n");
+writer.close();
+
+    const found = drainUntilId(alloc, reader, 5);
+    try std.testing.expect(found);
+}
+
+test "appserver: drainUntilId returns false on EOF before target id" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("{\"id\":1,\"result\":{}}\n");
+writer.close();
+
+    const found = drainUntilId(alloc, reader, 99);
+    try std.testing.expect(!found);
+}
+
+test "appserver: readThreadId extracts id from thread/start response" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    // id=0 should be skipped (readThreadId looks for id=1)
+    try writer.writeAll("{\"id\":0,\"result\":{}}\n");
+    try writer.writeAll("{\"id\":1,\"result\":{\"thread\":{\"id\":\"thread-xyz\"}}}\n");
+writer.close();
+
+    const tid = readThreadId(alloc, reader) orelse return error.TestExpectedThreadId;
+    defer alloc.free(tid);
+    try std.testing.expectEqualStrings("thread-xyz", tid);
+}
+
+test "appserver: readThreadId returns null when thread.id is missing" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    // id=1 response but no thread.id field
+    try writer.writeAll("{\"id\":1,\"result\":{\"other\":\"data\"}}\n");
+writer.close();
+
+    const tid = readThreadId(alloc, reader);
+    try std.testing.expectEqual(@as(?[]u8, null), tid);
+}
+
+test "appserver: streamTurn accumulates agentMessage deltas and stops at turn/completed" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("{\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"Hello, \"}}\n");
+    try writer.writeAll("{\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"world!\"}}\n");
+    try writer.writeAll("{\"method\":\"turn/completed\",\"params\":{\"turn\":{\"status\":\"completed\"}}}\n");
+writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    streamTurn(alloc, reader, &out);
+    try std.testing.expectEqualStrings("Hello, world!", out.items);
+}
+
+test "appserver: streamTurn appends error message on failed turn" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll(
+        \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"agent crashed"}}}}
+        ++ "\n",
+    );
+writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    streamTurn(alloc, reader, &out);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "agent crashed") != null);
 }

--- a/src/gh.zig
+++ b/src/gh.zig
@@ -129,7 +129,7 @@ pub fn runWithOutput(alloc: std.mem.Allocator, argv: []const []const u8) GhError
     };
 
     const stdout = stdout_ctx.buf.toOwnedSlice(alloc) catch {
-        stdout_ctx.deinit(alloc);
+        stdout_ctx.buf.deinit(alloc);
         stderr_ctx.buf.deinit(alloc);
         return GhError.OutOfMemory;
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,7 +33,7 @@ pub fn main() void {
         .mask = std.posix.sigemptyset(),
         .flags = 0,
     };
-    std.posix.sigaction(std.posix.SIG.PIPE, &act, null) catch {};
+    std.posix.sigaction(std.posix.SIG.PIPE, &act, null);
 
     var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer _ = gpa.deinit();
@@ -569,22 +569,22 @@ test "resolveRepoFromArgs supports repo_path, repo, and working_directory" {
     var params = std.json.ObjectMap.init(alloc);
     defer params.deinit();
 
-    try args.put("repo", "repo-a");
+    try args.put("repo", .{ .string = "repo-a" });
     try std.testing.expectEqualStrings("repo-a", resolveRepoFromArgs(&params, &args).?);
 
     args.clearRetainingCapacity();
-    try args.put("repo_path", "repo-b");
+    try args.put("repo_path", .{ .string = "repo-b" });
     try std.testing.expectEqualStrings("repo-b", resolveRepoFromArgs(&params, &args).?);
 
     args.clearRetainingCapacity();
-    try args.put("repo_path", "repo-b");
+    try args.put("repo_path", .{ .string = "repo-b" });
     try std.testing.expectEqualStrings("repo-b", resolveRepoFromArgs(&params, &args).?);
 
     args.clearRetainingCapacity();
-    try args.put("working_directory", "repo-c");
+    try args.put("working_directory", .{ .string = "repo-c" });
     try std.testing.expectEqualStrings("repo-c", resolveRepoFromArgs(&params, &args).?);
 
-    params.put("repo", "repo-p") catch return;
+    params.put("repo", .{ .string = "repo-p" }) catch return;
     try std.testing.expectEqualStrings("repo-p", resolveRepoFromArgs(&params, &args).?);
 }
 
@@ -605,19 +605,19 @@ test "thread table full falls back to default thread context" {
 
 test "protocol: readMessage accepts line-delimited JSON" {
     const alloc = std.testing.allocator;
-    var fds = try std.posix.pipe();
+    const fds = try std.posix.pipe();
     defer std.posix.close(fds[0]);
     defer std.posix.close(fds[1]);
 
-    var writer = std.fs.File{ .handle = fds[1] };
-    var reader = std.fs.File{ .handle = fds[0] };
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
 
     const payload = "{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}\n";
     try writer.writeAll(payload);
-    try writer.close();
+writer.close();
 
     var uses_headers = false;
-    const line = readMessage(alloc, reader, &uses_headers) orelse
+    const line = (try readMessage(alloc, reader, &uses_headers)) orelse
         return error.TestExpectedRead;
     defer alloc.free(line);
 
@@ -627,12 +627,12 @@ test "protocol: readMessage accepts line-delimited JSON" {
 
 test "protocol: readMessage accepts header-framed JSON" {
     const alloc = std.testing.allocator;
-    var fds = try std.posix.pipe();
+    const fds = try std.posix.pipe();
     defer std.posix.close(fds[0]);
     defer std.posix.close(fds[1]);
 
-    var writer = std.fs.File{ .handle = fds[1] };
-    var reader = std.fs.File{ .handle = fds[0] };
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
 
     const body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}";
     const frame = try std.fmt.allocPrint(
@@ -642,10 +642,10 @@ test "protocol: readMessage accepts header-framed JSON" {
     );
     defer alloc.free(frame);
     try writer.writeAll(frame);
-    try writer.close();
+writer.close();
 
     var uses_headers = false;
-    const read = readMessage(alloc, reader, &uses_headers) orelse
+    const read = (try readMessage(alloc, reader, &uses_headers)) orelse
         return error.TestExpectedRead;
     defer alloc.free(read);
 
@@ -671,16 +671,16 @@ test "protocol: writePayload emits selected framing mode" {
     const payload = "hello";
 
     {
-        var fds = try std.posix.pipe();
+        const fds = try std.posix.pipe();
         defer std.posix.close(fds[0]);
         defer std.posix.close(fds[1]);
 
-        var writer = std.fs.File{ .handle = fds[1] };
-        var reader = std.fs.File{ .handle = fds[0] };
+        const writer = std.fs.File{ .handle = fds[1] };
+        const reader = std.fs.File{ .handle = fds[0] };
 
         g_use_headers = false;
         try writePayload(writer, payload);
-        try writer.close();
+    writer.close();
 
         var got = std.ArrayList(u8).empty;
         defer got.deinit(alloc);
@@ -695,16 +695,16 @@ test "protocol: writePayload emits selected framing mode" {
     }
 
     {
-        var fds = try std.posix.pipe();
+        const fds = try std.posix.pipe();
         defer std.posix.close(fds[0]);
         defer std.posix.close(fds[1]);
 
-        var writer = std.fs.File{ .handle = fds[1] };
-        var reader = std.fs.File{ .handle = fds[0] };
+        const writer = std.fs.File{ .handle = fds[1] };
+        const reader = std.fs.File{ .handle = fds[0] };
 
         g_use_headers = true;
         try writePayload(writer, payload);
-        try writer.close();
+    writer.close();
 
         var got = std.ArrayList(u8).empty;
         defer got.deinit(alloc);
@@ -718,4 +718,207 @@ test "protocol: writePayload emits selected framing mode" {
         try std.testing.expect(std.mem.endsWith(u8, got.items, "\r\n"));
         try std.testing.expect(std.mem.containsAtLeast(u8, got.items, 1, payload));
     }
+}
+
+// ── Tests: protocol boundary / malformed inputs (#128) ───────────────────────
+
+test "protocol: readMessage returns null on immediate EOF" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    std.posix.close(fds[1]); // signal EOF immediately
+
+    const reader = std.fs.File{ .handle = fds[0] };
+    var uses_headers = false;
+    const line = try readMessage(alloc, reader, &uses_headers);
+    try std.testing.expectEqual(@as(?[]u8, null), line);
+}
+
+test "protocol: readMessage skips blank lines before JSON payload" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("\r\n\n{\"method\":\"ping\"}\n");
+writer.close();
+
+    var uses_headers = false;
+    const line = try readMessage(alloc, reader, &uses_headers) orelse
+        return error.TestExpectedMessage;
+    defer alloc.free(line);
+    try std.testing.expectEqualStrings("{\"method\":\"ping\"}", line);
+}
+
+test "protocol: readMessage returns InvalidMessage when header has no Content-Length" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    // Non-JSON start triggers header mode; no Content-Length before blank line
+    try writer.writeAll("X-Custom-Header: value\r\n\r\n");
+writer.close();
+
+    var uses_headers = false;
+    try std.testing.expectError(
+        error.InvalidMessage,
+        readMessage(alloc, reader, &uses_headers),
+    );
+}
+
+test "protocol: readMessage returns InvalidMessage when Content-Length exceeds max frame" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    const oversized = try std.fmt.allocPrint(
+        alloc, "Content-Length: {d}\r\n\r\n", .{MaxFrameBytes + 1},
+    );
+    defer alloc.free(oversized);
+    try writer.writeAll(oversized);
+writer.close();
+
+    var uses_headers = false;
+    try std.testing.expectError(
+        error.InvalidMessage,
+        readMessage(alloc, reader, &uses_headers),
+    );
+}
+
+test "protocol: readMessage returns InvalidMessage on truncated body" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    // Claim 100-byte body but only send 10 then close
+    try writer.writeAll("Content-Length: 100\r\n\r\n");
+    try writer.writeAll("only10byte");
+writer.close();
+
+    var uses_headers = false;
+    try std.testing.expectError(
+        error.InvalidMessage,
+        readMessage(alloc, reader, &uses_headers),
+    );
+}
+
+test "protocol: appendId handles integer, string, null, and non-scalar types" {
+    const alloc = std.testing.allocator;
+
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        appendId(alloc, &buf, .{ .integer = 42 });
+        try std.testing.expectEqualStrings("42", buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        appendId(alloc, &buf, .{ .string = "req-abc" });
+        try std.testing.expectEqualStrings("\"req-abc\"", buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        appendId(alloc, &buf, null);
+        try std.testing.expectEqualStrings("null", buf.items);
+    }
+    {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        // Non-scalar id (bool) → emits "null"
+        appendId(alloc, &buf, .{ .bool = true });
+        try std.testing.expectEqualStrings("null", buf.items);
+    }
+}
+
+test "protocol: writeError emits valid JSON-RPC 2.0 error structure" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const saved_headers = g_use_headers;
+    defer g_use_headers = saved_headers;
+    g_use_headers = false;
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    writeError(alloc, writer, .{ .integer = 7 }, -32600, "Invalid Request");
+writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    var buf: [1024]u8 = undefined;
+    while (true) {
+        const n = try reader.read(&buf);
+        if (n == 0) break;
+        try out.appendSlice(alloc, buf[0..n]);
+    }
+
+    const body = std.mem.trim(u8, out.items, " \r\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const obj = &parsed.value.object;
+    try std.testing.expectEqualStrings("2.0",
+        (obj.get("jsonrpc") orelse return error.MissingJsonrpc).string);
+    try std.testing.expectEqual(@as(i64, 7),
+        (obj.get("id") orelse return error.MissingId).integer);
+    const err_obj = (obj.get("error") orelse return error.MissingError).object;
+    try std.testing.expectEqual(@as(i64, -32600),
+        (err_obj.get("code") orelse return error.MissingCode).integer);
+    try std.testing.expectEqualStrings("Invalid Request",
+        (err_obj.get("message") orelse return error.MissingMessage).string);
+}
+
+test "protocol: writeResult emits valid JSON-RPC 2.0 result structure" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+
+    const saved_headers = g_use_headers;
+    defer g_use_headers = saved_headers;
+    g_use_headers = false;
+
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    writeResult(alloc, writer, .{ .string = "my-id" }, "{\"ok\":true}");
+writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    var buf: [1024]u8 = undefined;
+    while (true) {
+        const n = try reader.read(&buf);
+        if (n == 0) break;
+        try out.appendSlice(alloc, buf[0..n]);
+    }
+
+    const body = std.mem.trim(u8, out.items, " \r\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const obj = &parsed.value.object;
+    try std.testing.expectEqualStrings("2.0",
+        (obj.get("jsonrpc") orelse return error.MissingJsonrpc).string);
+    try std.testing.expectEqualStrings("my-id",
+        (obj.get("id") orelse return error.MissingId).string);
+    try std.testing.expect(obj.get("result") != null);
 }


### PR DESCRIPTION
## Summary

Fixes #161 — two bugs in `src/codex_appserver.zig`:

### 1. Auto-compact and retry on ContextWindowExceeded

`streamTurn` now returns `bool` instead of `void`:
- `true` = context window exceeded (check `codexErrorInfo == "ContextWindowExceeded"` first, fall back to message substring)
- `false` = all other outcomes

`runTurn_` compact-and-retry loop:
1. Detect `ContextWindowExceeded` from `streamTurn`
2. Clear partial output
3. Send `thread/compact/start` on the same thread
4. Drain the compaction turn (discard output)
5. Retry the original `turn/start` once — no infinite recursion on second failure

### 2. Fix `sandboxPolicy.type = "dangerFullAccess"`

Changed writable policy from `"unrestricted"` (not a valid type) to `"dangerFullAccess"` (most permissive valid type per Codex app-server docs). `approvalPolicy:"never"` is already set so no prompts appear.

### Bonus: two pre-existing compile errors fixed

- `main.zig`: `sigaction` returns `void` in Zig 0.15.x — removed spurious `catch {}`
- `gh.zig`: `DrainerCtx` has no `deinit()` — call `buf.deinit(alloc)` directly

## Test plan
- [ ] Build passes: `zig build`
- [ ] `run_reviewer` no longer hard-fails on long diffs — auto-compacts and retries
- [ ] Writable agents (`run_explorer`, `run_zig_infra`) use correct sandbox type
- [ ] `streamTurn` unit tests still pass