### PR TITLE
test: streamTurn ContextWindowExceeded unit tests (#128)

### DIFF
--- a/src/codex_appserver.zig
+++ b/src/codex_appserver.zig
@@ -532,7 +532,7 @@ writer.close();
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(alloc);
-    streamTurn(alloc, reader, &out);
+    _ = streamTurn(alloc, reader, &out);
     try std.testing.expectEqualStrings("Hello, world!", out.items);
 }
 
@@ -553,6 +553,114 @@ writer.close();
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(alloc);
-    streamTurn(alloc, reader, &out);
+    _ = streamTurn(alloc, reader, &out);
     try std.testing.expect(std.mem.indexOf(u8, out.items, "agent crashed") != null);
+}
+
+test "appserver: streamTurn returns true on ContextWindowExceeded via codexErrorInfo" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll(
+        \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"context full","codexErrorInfo":"ContextWindowExceeded"}}}}
+        ++ "\n",
+    );
+    writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    const exceeded = streamTurn(alloc, reader, &out);
+    try std.testing.expect(exceeded);
+    // output should be empty — caller is responsible for compact+retry
+    try std.testing.expectEqualStrings("", out.items);
+}
+
+test "appserver: streamTurn returns true on context window message substring fallback" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll(
+        \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"Codex ran out of room in the model's context window. Start a new thread."}}}}
+        ++ "\n",
+    );
+    writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    const exceeded = streamTurn(alloc, reader, &out);
+    try std.testing.expect(exceeded);
+    try std.testing.expectEqualStrings("", out.items);
+}
+
+test "appserver: streamTurn returns false on non-context-window failure" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll(
+        \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"internal server error","codexErrorInfo":"InternalServerError"}}}}
+        ++ "\n",
+    );
+    writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    const exceeded = streamTurn(alloc, reader, &out);
+    try std.testing.expect(!exceeded);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "internal server error") != null);
+}
+
+test "appserver: streamTurn returns false on successful turn with no output" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll(
+        \\{"method":"turn/completed","params":{"turn":{"status":"completed"}}}
+        ++ "\n",
+    );
+    writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    const exceeded = streamTurn(alloc, reader, &out);
+    try std.testing.expect(!exceeded);
+    try std.testing.expectEqualStrings("", out.items);
+}
+
+test "appserver: streamTurn skips unknown notifications before turn/completed" {
+    const alloc = std.testing.allocator;
+    const fds = try std.posix.pipe();
+    defer std.posix.close(fds[0]);
+    defer std.posix.close(fds[1]);
+    const writer = std.fs.File{ .handle = fds[1] };
+    const reader = std.fs.File{ .handle = fds[0] };
+
+    try writer.writeAll("{\"method\":\"thread/status/changed\",\"params\":{}}\n");
+    try writer.writeAll("{\"method\":\"item/started\",\"params\":{\"item\":{\"type\":\"agentMessage\"}}}\n");
+    try writer.writeAll("{\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"result\"}}\n");
+    try writer.writeAll(
+        \\{"method":"turn/completed","params":{"turn":{"status":"completed"}}}
+        ++ "\n",
+    );
+    writer.close();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    _ = streamTurn(alloc, reader, &out);
+    try std.testing.expectEqualStrings("result", out.items);
 }


### PR DESCRIPTION
## Summary
- Adds 5 new unit tests for `streamTurn` covering ContextWindowExceeded detection (via `codexErrorInfo` field and message substring fallback), non-context-window failures, successful turns, and unknown notification skipping
- Fixes `_ = streamTurn()` in two existing tests to suppress unused-return-value warning after `streamTurn` return type changed to `bool` in #162

## Test plan
- [ ] `zig build test` passes (pre-commit hook verified)
- [ ] All 5 new tests exercise the bool return from `streamTurn`
- [ ] Closes part of #128 (unit test coverage)