### PR TITLE
fix: use macos-latest for aarch64-macos runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,11 @@ jobs:
             os: ubuntu-latest
             asset: gitagent-mcp-aarch64-linux
           - target: x86_64-macos
-            os: macos-13
+            os: ubuntu-latest
             asset: gitagent-mcp-x86_64-macos
           - target: aarch64-macos
             os: macos-latest
             asset: gitagent-mcp-aarch64-macos
-    steps:
       - uses: actions/checkout@v4
 
       - name: Install Zig 0.15.1


### PR DESCRIPTION
macos-13 was retired Dec 2025. Native arm64 on macos-latest, cross-compile x86_64-macos from ubuntu-latest via Zig.