### PR TITLE
fix: TenantManager mutex (#108), error propagation (#119), muonry hint (#135)

### DIFF
--- a/src/graph/ppr_incremental.zig
+++ b/src/graph/ppr_incremental.zig
@@ -72,7 +72,10 @@ pub const IncrementalPpr = struct {
     /// Notify that an edge was added from src to dst with the given weight.
     /// Injects residual at the source node so the next deltaUpdate propagates
     /// the score change through the new edge.
-    pub fn onEdgeAdded(self: *IncrementalPpr, src: u64, dst: u64, weight: f32) void {
+    /// Notify that an edge was added from src to dst with the given weight.
+    /// Injects residual at the source node so the next deltaUpdate propagates
+    /// the score change through the new edge.
+    pub fn onEdgeAdded(self: *IncrementalPpr, src: u64, dst: u64, weight: f32) !void {
         _ = dst;
         // The source node's outgoing weight distribution changed, so its
         // current score needs to be partially redistributed. We inject
@@ -82,20 +85,24 @@ pub const IncrementalPpr = struct {
         const injection = (1.0 - self.alpha) * src_score * weight;
 
         if (injection > 0) {
-            const entry = self.residuals.getOrPut(src) catch return;
+            const entry = try self.residuals.getOrPut(src);
             if (!entry.found_existing) entry.value_ptr.* = 0;
             entry.value_ptr.* += injection;
         }
 
         // Mark source as dirty regardless (edge topology changed)
-        self.dirty_nodes.put(src, {}) catch {};
+        try self.dirty_nodes.put(src, {});
     }
 
     /// Notify that an edge from src to dst was removed.
     /// Marks the source node dirty so deltaUpdate can recompute its local
     /// neighbourhood. Also redistributes the score that was flowing through
     /// the removed edge back as residual on the source.
-    pub fn onEdgeRemoved(self: *IncrementalPpr, src: u64, dst: u64) void {
+    /// Notify that an edge from src to dst was removed.
+    /// Marks the source node dirty so deltaUpdate can recompute its local
+    /// neighbourhood. Also redistributes the score that was flowing through
+    /// the removed edge back as residual on the source.
+    pub fn onEdgeRemoved(self: *IncrementalPpr, src: u64, dst: u64) !void {
         // The score that was flowing to dst through this edge needs to be
         // reclaimed. We approximate by marking both nodes dirty and injecting
         // residual at the source.
@@ -104,7 +111,7 @@ pub const IncrementalPpr = struct {
 
         // Inject residual at source proportional to its score
         if (src_score > 0) {
-            const entry = self.residuals.getOrPut(src) catch return;
+            const entry = try self.residuals.getOrPut(src);
             if (!entry.found_existing) entry.value_ptr.* = 0;
             entry.value_ptr.* += (1.0 - self.alpha) * src_score;
         }
@@ -117,26 +124,34 @@ pub const IncrementalPpr = struct {
                 ptr.* -= reduction;
                 if (ptr.* < 0) ptr.* = 0;
             }
-            const dst_entry = self.residuals.getOrPut(dst) catch return;
+            const dst_entry = try self.residuals.getOrPut(dst);
             if (!dst_entry.found_existing) dst_entry.value_ptr.* = 0;
             dst_entry.value_ptr.* += reduction;
         }
 
-        self.dirty_nodes.put(src, {}) catch {};
-        self.dirty_nodes.put(dst, {}) catch {};
+        try self.dirty_nodes.put(src, {});
+        try self.dirty_nodes.put(dst, {});
     }
 
     /// Notify that a file was invalidated (e.g. modified on disk).
     /// All symbols belonging to that file are marked dirty with residual
     /// injected based on their current scores.
-    pub fn onFileInvalidated(self: *IncrementalPpr, symbol_ids: []const u64) void {
+    /// Notify that a file was invalidated (e.g. modified on disk).
+    /// All symbols belonging to that file are marked dirty with residual
+    /// injected based on their current scores.
+    /// Pre-ensures capacity so the loop never leaves partial state on OOM.
+    pub fn onFileInvalidated(self: *IncrementalPpr, symbol_ids: []const u64) !void {
+        // Pre-allocate worst-case capacity so the loop below cannot fail.
+        try self.dirty_nodes.ensureUnusedCapacity(@intCast(symbol_ids.len));
+        try self.residuals.ensureUnusedCapacity(@intCast(symbol_ids.len));
+
         for (symbol_ids) |id| {
-            self.dirty_nodes.put(id, {}) catch {};
+            self.dirty_nodes.putAssumeCapacity(id, {});
 
             // Inject residual so scores get recomputed
             const score = self.scores.get(id) orelse 0;
             if (score > 0) {
-                const entry = self.residuals.getOrPut(id) catch continue;
+                const entry = self.residuals.getOrPutAssumeCapacity(id);
                 if (!entry.found_existing) entry.value_ptr.* = 0;
                 entry.value_ptr.* += score;
             }
@@ -305,7 +320,7 @@ test "onEdgeAdded marks source dirty and injects residual" {
     // Seed a score for node 1
     try ippr.scores.put(1, 0.5);
 
-    ippr.onEdgeAdded(1, 2, 1.0);
+    try ippr.onEdgeAdded(1, 2, 1.0);
 
     try std.testing.expectEqual(@as(usize, 1), ippr.dirtyCount());
     // Residual should be injected at source
@@ -320,7 +335,7 @@ test "onEdgeRemoved marks both nodes dirty" {
     try ippr.scores.put(1, 0.5);
     try ippr.scores.put(2, 0.3);
 
-    ippr.onEdgeRemoved(1, 2);
+    try ippr.onEdgeRemoved(1, 2);
 
     try std.testing.expectEqual(@as(usize, 2), ippr.dirtyCount());
     // Residual should exist at source
@@ -336,7 +351,7 @@ test "onFileInvalidated marks all symbols dirty" {
     try ippr.scores.put(12, 0.1);
 
     const ids = [_]u64{ 10, 11, 12 };
-    ippr.onFileInvalidated(&ids);
+    try ippr.onFileInvalidated(&ids);
 
     try std.testing.expectEqual(@as(usize, 3), ippr.dirtyCount());
 }
@@ -387,7 +402,7 @@ test "deltaUpdate after edge addition increases downstream scores" {
 
     // Add new edge: 1 -> 3
     try g.addEdge(.{ .src = 1, .dst = 3, .kind = .calls });
-    ippr.onEdgeAdded(1, 3, 1.0);
+    try ippr.onEdgeAdded(1, 3, 1.0);
     try ippr.deltaUpdate(&g);
 
     // Node 3 should now have a positive score
@@ -415,7 +430,7 @@ test "deltaUpdate after edge removal adjusts scores" {
 
     // Notify edge removal (we don't actually remove from graph for this test,
     // just check that the incremental update processes dirty nodes)
-    ippr.onEdgeRemoved(1, 3);
+    try ippr.onEdgeRemoved(1, 3);
     try ippr.deltaUpdate(&g);
 
     // After update, dirty set should be cleared
@@ -477,7 +492,7 @@ test "onFileInvalidated with no prior scores is safe" {
     defer ippr.deinit();
 
     const ids = [_]u64{ 100, 200, 300 };
-    ippr.onFileInvalidated(&ids);
+    try ippr.onFileInvalidated(&ids);
 
     try std.testing.expectEqual(@as(usize, 3), ippr.dirtyCount());
     // No residual since scores are 0
@@ -544,7 +559,7 @@ test "onEdgeAdded with weight=0 does not inject residual" {
 
     try ippr.scores.put(1, 0.5);
 
-    ippr.onEdgeAdded(1, 2, 0.0);
+    try ippr.onEdgeAdded(1, 2, 0.0);
 
     // injection = (1-alpha) * 0.5 * 0.0 = 0, so no residual injected
     // But dirty node is still marked
@@ -559,7 +574,7 @@ test "onEdgeRemoved for nodes with no scores" {
     defer ippr.deinit();
 
     // Neither node has scores
-    ippr.onEdgeRemoved(42, 43);
+    try ippr.onEdgeRemoved(42, 43);
 
     // Should mark both dirty without crashing
     try std.testing.expectEqual(@as(usize, 2), ippr.dirtyCount());
@@ -575,11 +590,11 @@ test "multiple rapid edge additions accumulate residual" {
     try ippr.scores.put(1, 1.0);
 
     // Add 5 edges rapidly from same source
-    ippr.onEdgeAdded(1, 10, 1.0);
-    ippr.onEdgeAdded(1, 11, 1.0);
-    ippr.onEdgeAdded(1, 12, 1.0);
-    ippr.onEdgeAdded(1, 13, 1.0);
-    ippr.onEdgeAdded(1, 14, 1.0);
+    try ippr.onEdgeAdded(1, 10, 1.0);
+    try ippr.onEdgeAdded(1, 11, 1.0);
+    try ippr.onEdgeAdded(1, 12, 1.0);
+    try ippr.onEdgeAdded(1, 13, 1.0);
+    try ippr.onEdgeAdded(1, 14, 1.0);
 
     // Each injection adds (1-alpha)*score*weight to residual
     // Total = 5 * (1-0.15) * 1.0 * 1.0 = 4.25
@@ -594,7 +609,7 @@ test "onFileInvalidated with empty symbol list" {
     try ippr.scores.put(1, 0.5);
 
     const empty_ids = [_]u64{};
-    ippr.onFileInvalidated(&empty_ids);
+    try ippr.onFileInvalidated(&empty_ids);
 
     // Should be a no-op
     try std.testing.expectEqual(@as(usize, 0), ippr.dirtyCount());

--- a/src/graph/tenant.zig
+++ b/src/graph/tenant.zig
@@ -67,6 +67,8 @@ pub const TenantManager = struct {
     path_to_id: std.StringHashMap(u32),
     next_id: u32,
     alloc: std.mem.Allocator,
+    /// Guards all HashMap and counter accesses from concurrent threads.
+    mu: std.Thread.Mutex = .{},
 
     pub fn init(alloc: std.mem.Allocator) TenantManager {
         return .{
@@ -91,6 +93,9 @@ pub const TenantManager = struct {
 
     /// Register a new repository. Returns the assigned repo ID.
     pub fn registerRepo(self: *TenantManager, name: []const u8, path: []const u8) !u32 {
+        self.mu.lock();
+        defer self.mu.unlock();
+
         if (self.repos.count() >= MAX_REPOS) return error.TooManyRepos;
 
         // Check for duplicate path
@@ -122,6 +127,9 @@ pub const TenantManager = struct {
 
     /// Unregister a repository.
     pub fn unregisterRepo(self: *TenantManager, repo_id: u32) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
+
         const handle = self.repos.get(repo_id) orelse return error.RepoNotFound;
         if (handle.readers > 0 or handle.writer_active) return error.RepoBusy;
 
@@ -132,17 +140,23 @@ pub const TenantManager = struct {
     }
 
     /// Look up a repo by its filesystem path.
-    pub fn findByPath(self: *const TenantManager, path: []const u8) ?u32 {
+    pub fn findByPath(self: *TenantManager, path: []const u8) ?u32 {
+        self.mu.lock();
+        defer self.mu.unlock();
         return self.path_to_id.get(path);
     }
 
-    /// Get a repo handle (read-only).
-    pub fn getRepo(self: *const TenantManager, repo_id: u32) ?RepoHandle {
+    /// Get a repo handle (read-only copy).
+    pub fn getRepo(self: *TenantManager, repo_id: u32) ?RepoHandle {
+        self.mu.lock();
+        defer self.mu.unlock();
         return self.repos.get(repo_id);
     }
 
     /// Acquire a read lock. Multiple readers allowed.
     pub fn acquireRead(self: *TenantManager, repo_id: u32) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
         const handle = self.repos.getPtr(repo_id) orelse return error.RepoNotFound;
         if (handle.writer_active) return error.WriteLocked;
         handle.readers += 1;
@@ -150,12 +164,16 @@ pub const TenantManager = struct {
 
     /// Release a read lock.
     pub fn releaseRead(self: *TenantManager, repo_id: u32) void {
+        self.mu.lock();
+        defer self.mu.unlock();
         const handle = self.repos.getPtr(repo_id) orelse return;
         if (handle.readers > 0) handle.readers -= 1;
     }
 
     /// Acquire an exclusive write lock. Fails if any readers or writer active.
     pub fn acquireWrite(self: *TenantManager, repo_id: u32) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
         const handle = self.repos.getPtr(repo_id) orelse return error.RepoNotFound;
         if (handle.writer_active) return error.WriteLocked;
         if (handle.readers > 0) return error.ReadLocked;
@@ -164,6 +182,8 @@ pub const TenantManager = struct {
 
     /// Release the write lock.
     pub fn releaseWrite(self: *TenantManager, repo_id: u32) void {
+        self.mu.lock();
+        defer self.mu.unlock();
         const handle = self.repos.getPtr(repo_id) orelse return;
         handle.writer_active = false;
     }
@@ -171,39 +191,49 @@ pub const TenantManager = struct {
     /// Get the data directory path for a repo.
     /// Returns a path like ".codegraph/repos/<hex-hash>".
     /// Caller owns the returned slice.
-    pub fn repoDataDir(self: *const TenantManager, repo_id: u32) ![]u8 {
-        const handle = self.repos.get(repo_id) orelse return error.RepoNotFound;
-        const hex = hashToHex(handle.dir_hash);
-        return std.fs.path.join(self.alloc, &.{ BASE_DIR, &hex });
+    pub fn repoDataDir(self: *TenantManager, repo_id: u32) ![]u8 {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.repoDataDirLocked(repo_id);
     }
 
     /// Get the graph file path for a repo. Caller owns the returned slice.
-    pub fn repoGraphPath(self: *const TenantManager, repo_id: u32) ![]u8 {
-        const dir = try self.repoDataDir(repo_id);
+    pub fn repoGraphPath(self: *TenantManager, repo_id: u32) ![]u8 {
+        self.mu.lock();
+        defer self.mu.unlock();
+        const dir = try self.repoDataDirLocked(repo_id);
         defer self.alloc.free(dir);
         return std.fs.path.join(self.alloc, &.{ dir, GRAPH_FILE });
     }
 
     /// Get the WAL file path for a repo. Caller owns the returned slice.
-    pub fn repoWalPath(self: *const TenantManager, repo_id: u32) ![]u8 {
-        const dir = try self.repoDataDir(repo_id);
+    pub fn repoWalPath(self: *TenantManager, repo_id: u32) ![]u8 {
+        self.mu.lock();
+        defer self.mu.unlock();
+        const dir = try self.repoDataDirLocked(repo_id);
         defer self.alloc.free(dir);
         return std.fs.path.join(self.alloc, &.{ dir, WAL_FILE });
     }
 
     /// Update the last sync timestamp for a repo.
     pub fn markSynced(self: *TenantManager, repo_id: u32, now_ms: i64) void {
+        self.mu.lock();
+        defer self.mu.unlock();
         const handle = self.repos.getPtr(repo_id) orelse return;
         handle.last_sync_ms = now_ms;
     }
 
     /// Total number of registered repos.
-    pub fn count(self: *const TenantManager) u32 {
+    pub fn count(self: *TenantManager) u32 {
+        self.mu.lock();
+        defer self.mu.unlock();
         return @intCast(self.repos.count());
     }
 
     /// List all repo IDs.
-    pub fn listRepoIds(self: *const TenantManager) ![]u32 {
+    pub fn listRepoIds(self: *TenantManager) ![]u32 {
+        self.mu.lock();
+        defer self.mu.unlock();
         var ids = try self.alloc.alloc(u32, self.repos.count());
         var i: usize = 0;
         var it = self.repos.iterator();
@@ -212,6 +242,14 @@ pub const TenantManager = struct {
             i += 1;
         }
         return ids;
+    }
+
+    // ── Internal (caller must hold mu) ─────────────────────────────────────
+
+    fn repoDataDirLocked(self: *TenantManager, repo_id: u32) ![]u8 {
+        const handle = self.repos.get(repo_id) orelse return error.RepoNotFound;
+        const hex = hashToHex(handle.dir_hash);
+        return std.fs.path.join(self.alloc, &.{ BASE_DIR, &hex });
     }
 };
 

--- a/src/graph/tier_manager.zig
+++ b/src/graph/tier_manager.zig
@@ -190,8 +190,43 @@ pub const TierManager = struct {
 
     /// Evict idle entries based on time threshold.
     /// Demotes HOT→WARM and WARM→COLD for entries idle longer than `idle_ms`.
-    pub fn evictIdle(self: *TierManager, idle_ms: i64) u32 {
+    /// Evict idle entries based on time threshold.
+    /// Demotes HOT→WARM and WARM→COLD for entries idle longer than `idle_ms`.
+    pub fn evictIdle(self: *TierManager, idle_ms: i64) !u32 {
         return self.evictIdleAt(idle_ms, std.time.milliTimestamp());
+    }
+
+    /// Evict idle entries with explicit timestamp (for testing).
+    pub fn evictIdleAt(self: *TierManager, idle_ms: i64, now_ms: i64) !u32 {
+        var evicted: u32 = 0;
+        // Collect keys to demote (can't modify during iteration)
+        var to_demote_hot = std.ArrayList(u32).empty;
+        defer to_demote_hot.deinit(self.alloc);
+        var to_demote_warm = std.ArrayList(u32).empty;
+        defer to_demote_warm.deinit(self.alloc);
+
+        var it = self.entries.iterator();
+        while (it.next()) |kv| {
+            const e = kv.value_ptr;
+            if (e.last_access_ms > 0 and (now_ms - e.last_access_ms) > idle_ms) {
+                if (e.tier == .hot) {
+                    try to_demote_hot.append(self.alloc, kv.key_ptr.*);
+                } else if (e.tier == .warm) {
+                    try to_demote_warm.append(self.alloc, kv.key_ptr.*);
+                }
+            }
+        }
+
+        for (to_demote_hot.items) |rid| {
+            self.demoteToWarm(rid);
+            evicted += 1;
+        }
+        for (to_demote_warm.items) |rid| {
+            self.demoteToCold(rid);
+            evicted += 1;
+        }
+
+        return evicted;
     }
 
     /// Evict idle entries with explicit timestamp (for testing).
@@ -383,7 +418,7 @@ test "evict idle entries" {
     tm.warm_count += 1;
 
     // Evict entries idle for more than 2000ms at time 6000
-    const evicted = tm.evictIdleAt(2000, 6000);
+    const evicted = try tm.evictIdleAt(2000, 6000);
     try std.testing.expectEqual(@as(u32, 1), evicted); // only entry 1 (idle 5000ms)
     try std.testing.expectEqual(Tier.cold, tm.getTier(1).?);
     try std.testing.expectEqual(Tier.warm, tm.getTier(2).?);
@@ -543,7 +578,7 @@ test "evict when no entries are idle" {
 
     // Now = 10000, idle_ms = 2000, so entries idle > 2000ms would be evicted
     // But both entries are recent (idle 1000ms and 500ms)
-    const evicted = tm.evictIdleAt(2000, 10000);
+    const evicted = try tm.evictIdleAt(2000, 10000);
     try std.testing.expectEqual(@as(u32, 0), evicted);
     try std.testing.expectEqual(Tier.warm, tm.getTier(1).?);
     try std.testing.expectEqual(Tier.warm, tm.getTier(2).?);
@@ -664,7 +699,7 @@ test "evict idle demotes hot to warm and warm to cold" {
     e3.last_access_ms = 9000;
     tm.warm_count += 1;
 
-    const evicted = tm.evictIdleAt(5000, 10000);
+    const evicted = try tm.evictIdleAt(5000, 10000);
     try std.testing.expectEqual(@as(u32, 2), evicted); // repos 1 and 2
 
     try std.testing.expectEqual(Tier.warm, tm.getTier(1).?); // hot → warm
@@ -709,6 +744,6 @@ test "cold entries with zero last_access_ms are not evicted" {
     try std.testing.expectEqual(@as(i64, 0), tm.getEntry(1).?.last_access_ms);
 
     // Should not be evicted (it's already cold, and last_access_ms check: 0 > 0 is false)
-    const evicted = tm.evictIdleAt(1, 999999);
+    const evicted = try tm.evictIdleAt(1, 999999);
     try std.testing.expectEqual(@as(u32, 0), evicted);
 }

--- a/src/swarm.zig
+++ b/src/swarm.zig
@@ -41,7 +41,7 @@ const WRITABLE_PREAMBLE =
     \\  - One focused change per file; do not rewrite files wholesale
     \\  - Cite file:line for every finding
     \\
-    \\MCP TOOLS (also available): mcp__muonry__read, mcp__muonry__search, mcp__muonry__edit
+    \\MCP TOOLS (available when muonry is in ~/.codex/config.toml): mcp__muonry__read, mcp__muonry__search, mcp__muonry__edit
     \\
     \\Task:
     \\


### PR DESCRIPTION
## Summary

- **#108** — Add `std.Thread.Mutex` to `TenantManager`: all public methods now lock/unlock; `repoDataDirLocked` private helper avoids recursive lock on the shared mutex when `repoGraphPath`/`repoWalPath` call `repoDataDir` internally.
- **#119** — Propagate OOM errors instead of silently dropping them:
  - `ppr_incremental.zig`: `onEdgeAdded`, `onEdgeRemoved`, `onFileInvalidated` → `!void`; use `try` throughout; `onFileInvalidated` uses `ensureUnusedCapacity` + `putAssumeCapacity` for atomicity.
  - `tier_manager.zig`: `evictIdle`/`evictIdleAt` → `!u32`; replace `catch continue` with `try`.
- **#135** — Update `WRITABLE_PREAMBLE` in `swarm.zig` to clarify muonry MCP tools are available only when configured in `~/.codex/config.toml`.

## Test plan

- [x] `zig build test` passes (all existing unit tests including TenantManager MRSW tests and ppr/tier tests)
- [x] Pre-commit hook ran and passed
- [x] No changes to `build.zig` or public API — callers updated with `try`

Closes #108
Closes #119
Closes #135