### PR TITLE
feat: graceful labels, branch-aware run_agent, swarm manifest, codedb preamble (#239-242)

### DIFF
--- a/src/swarm.zig
+++ b/src/swarm.zig
@@ -34,12 +34,20 @@ const WRITABLE_PREAMBLE =
     \\  zigcreate FILE --content "..."   # create new file
     \\  zigdiff FILE                     # verify edit landed correctly
     \\
+    \\CODEDB GRAPH TOOLS (if codedb binary is on PATH):
+    \\  codedb outline FILE              # structural outline with symbols
+    \\  codedb deps FILE                 # reverse dependencies (who imports this file)
+    \\  codedb symbol NAME               # find all definitions of a symbol
+    \\  codedb search "query"            # full-text search across indexed files
+    \\  codedb hot                       # recently modified files
+    \\
     \\RULES:
     \\  - NEVER use sed, awk, patch, tee, echo/printf redirects (>, >>), or heredocs to write files
     \\  - NEVER write raw diff/patch syntax into source files
     \\  - Always zigread before zigpatch; always zigdiff after zigpatch
     \\  - One focused change per file; do not rewrite files wholesale
     \\  - Cite file:line for every finding
+    \\  - Prefer zigpatch -s SYMBOL for multi-iteration edits (immune to line drift)
     \\
     \\MCP TOOLS (available when muonry is in ~/.codex/config.toml): mcp__muonry__read, mcp__muonry__search, mcp__muonry__edit
     \\
@@ -180,6 +188,22 @@ pub fn runSwarm(
         if (w.allocated_prompt) |p| alloc.free(p);
     }
 
+    // ── Phase 3b: Capture file manifest for writable swarms ──────────────
+    var manifest: []const u8 = "";
+    var manifest_alloc: ?[]u8 = null;
+    defer if (manifest_alloc) |m| alloc.free(m);
+    if (policy == .writable) {
+        const gh = @import("gh.zig");
+        if (gh.run(alloc, &.{ "git", "diff", "--stat", "HEAD" })) |dr| {
+            defer dr.deinit(alloc);
+            const trimmed = std.mem.trim(u8, dr.stdout, " \t\n\r");
+            if (trimmed.len > 0) {
+                manifest_alloc = alloc.dupe(u8, trimmed) catch null;
+                if (manifest_alloc) |m| manifest = m;
+            }
+        } else |_| {}
+    }
+
     // ── Phase 4: Build synthesis prompt from worker results ───────────────
     var synth: std.ArrayList(u8) = .empty;
     defer synth.deinit(alloc);
@@ -198,6 +222,13 @@ pub fn runSwarm(
         synth.appendSlice(alloc, w.out.items) catch {};
         synth.appendSlice(alloc, "\n\n") catch {};
         w.out.deinit(std.heap.page_allocator);
+    }
+
+    // Include file manifest in synthesis if available
+    if (manifest.len > 0) {
+        synth.appendSlice(alloc, "## Files Changed\n```\n") catch {};
+        synth.appendSlice(alloc, manifest) catch {};
+        synth.appendSlice(alloc, "\n```\n\n") catch {};
     }
 
     synth.appendSlice(alloc, "Synthesize the above into a final answer.") catch {};

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -453,10 +453,19 @@ fn handleCreateIssue(
     argv.appendSlice(alloc, &.{ "gh", "issue", "create", "--repo", currentRepo(), "--title", title, "--body", body }) catch return;
 
     var has_status = false;
+    // Track skipped labels for warnings
+    var skipped: std.ArrayList([]const u8) = .empty;
+    defer skipped.deinit(alloc);
+
     if (args.get("labels")) |lv| {
         if (lv == .array) {
             for (lv.array.items) |lbl| {
                 if (lbl != .string) continue;
+                // Check if label exists in the repo cache; skip if missing
+                if (cache.getLabel(lbl.string) == null and !std.mem.startsWith(u8, lbl.string, "status:") and !std.mem.startsWith(u8, lbl.string, "priority:")) {
+                    skipped.appendSlice(alloc, &.{lbl.string}) catch {};
+                    continue;
+                }
                 argv.appendSlice(alloc, &.{ "--label", lbl.string }) catch return;
                 if (std.mem.startsWith(u8, lbl.string, "status:")) has_status = true;
             }
@@ -489,7 +498,20 @@ fn handleCreateIssue(
     mj.writeEscaped(alloc, out, url);
     out.appendSlice(alloc, "\",\"title\":\"") catch return;
     mj.writeEscaped(alloc, out, title);
-    out.appendSlice(alloc, "\"}") catch {};
+    out.appendSlice(alloc, "\"") catch {};
+
+    // Include warnings for skipped labels
+    if (skipped.items.len > 0) {
+        out.appendSlice(alloc, ",\"warnings\":[") catch {};
+        for (skipped.items, 0..) |s, i| {
+            if (i > 0) out.appendSlice(alloc, ",") catch {};
+            out.appendSlice(alloc, "\"label not found: ") catch {};
+            mj.writeEscaped(alloc, out, s);
+            out.appendSlice(alloc, "\"") catch {};
+        }
+        out.appendSlice(alloc, "]") catch {};
+    }
+    out.appendSlice(alloc, "}") catch {};
 }
 
 fn handleCreateIssuesBatch(
@@ -2075,6 +2097,50 @@ fn handleRunAgent(
         return;
     };
 
+    // Build context-enriched prompt: branch, issue, recent commits
+    const enriched = blk: {
+        var ctx: std.ArrayList(u8) = .empty;
+        defer ctx.deinit(alloc);
+
+        // Current branch
+        if (gh.run(alloc, &.{ "git", "branch", "--show-current" })) |br| {
+            defer br.deinit(alloc);
+            const branch = std.mem.trim(u8, br.stdout, " \t\n\r");
+            if (branch.len > 0) {
+                ctx.appendSlice(alloc, "CONTEXT: branch=") catch {};
+                ctx.appendSlice(alloc, branch) catch {};
+                // Parse issue number from branch name
+                if (state.parseIssueNumber(branch)) |n| {
+                    var nb: [16]u8 = undefined;
+                    const ns = std.fmt.bufPrint(&nb, ", issue=#{d}", .{n}) catch "";
+                    ctx.appendSlice(alloc, ns) catch {};
+                }
+                ctx.appendSlice(alloc, "\n") catch {};
+            }
+        } else |_| {}
+
+        // Recent commits
+        if (gh.run(alloc, &.{ "git", "log", "-3", "--oneline" })) |lr| {
+            defer lr.deinit(alloc);
+            const log = std.mem.trim(u8, lr.stdout, " \t\n\r");
+            if (log.len > 0) {
+                ctx.appendSlice(alloc, "RECENT COMMITS:\n") catch {};
+                ctx.appendSlice(alloc, log) catch {};
+                ctx.appendSlice(alloc, "\n") catch {};
+            }
+        } else |_| {}
+
+        if (ctx.items.len > 0) {
+            ctx.appendSlice(alloc, "\n") catch {};
+            ctx.appendSlice(alloc, prompt) catch {};
+            break :blk alloc.dupe(u8, ctx.items) catch null;
+        }
+        break :blk null;
+    };
+    defer if (enriched) |e| alloc.free(e);
+
+    const final_prompt = enriched orelse prompt;
+
     const opts: sdk.AgentOptions = .{
         .allowed_tools   = mj.getStr(args, "allowed_tools"),
         .permission_mode = mj.getStr(args, "permission_mode"),
@@ -2087,5 +2153,5 @@ fn handleRunAgent(
         },
     };
 
-    sdk.runAgent(alloc, prompt, opts, out);
+    sdk.runAgent(alloc, final_prompt, opts, out);
 }


### PR DESCRIPTION
## Summary

Implements the remaining 4 features from Blackfloofie's feedback:

- **Graceful label handling** (#239) — `create_issue` now checks labels against the cache before passing to `gh`. Missing labels are skipped and reported in a `"warnings"` array in the response. Known prefixes (`status:`, `priority:`) are always passed through.

- **Branch-aware context injection** (#240) — `run_agent` now auto-injects current branch name, linked issue number, and last 3 commits into the prompt preamble. Saves tokens and improves agent accuracy.

- **Writable swarm file manifest** (#241) — After all worker threads join in a writable swarm, `git diff --stat HEAD` captures what files changed. The manifest is included in the synthesis prompt under `## Files Changed` so the synthesis agent can summarize changes accurately.

- **Sub-agent codedb graph tools** (#242) — `WRITABLE_PREAMBLE` now documents codedb CLI commands (`codedb outline`, `codedb deps`, `codedb symbol`, `codedb search`, `codedb hot`) and emphasizes `zigpatch -s SYMBOL` for multi-iteration edits.

## Test plan

- [x] `zig build test` passes (including existing swarm preamble tests)
- [x] No new tool registrations needed — changes are to existing handler internals and preamble text

Closes #239
Closes #240
Closes #241
Closes #242