### PR TITLE
ci: fix codesign identity not found in keychain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,30 +20,26 @@ jobs:
             asset: devswarm-aarch64-linux
     steps:
       - uses: actions/checkout@v4
-
       - name: Install Zig 0.15.1
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.1
-
       - name: Build
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} -Dversion="$VERSION"
-
       - name: Package
         run: |
           mkdir -p dist
           cp zig-out/bin/devswarm dist/${{ matrix.asset }}
           cd dist && sha256sum ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
-
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
           path: dist/
 
   build-macos:
-    name: Build ${{ matrix.target }}
+    name: Build ${{ matrix.target }} (signed)
     runs-on: macos-latest
     strategy:
       matrix:
@@ -54,23 +50,53 @@ jobs:
             asset: devswarm-aarch64-macos
     steps:
       - uses: actions/checkout@v4
-
       - name: Install Zig 0.15.1
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.1
-
       - name: Build
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} -Dversion="$VERSION"
-
+      - name: Import signing certificate
+        env:
+          CERT_B64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT }}
+          CERT_PASS: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          echo "$CERT_B64" | base64 --decode > /tmp/cert.p12
+          KEYCHAIN_PASS=$(openssl rand -hex 16)
+          security create-keychain -p "$KEYCHAIN_PASS" build.keychain
+          security list-keychains -d user -s build.keychain $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASS" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import /tmp/cert.p12 -k build.keychain -P "$CERT_PASS" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" build.keychain
+          rm /tmp/cert.p12
+          security find-identity -v -p codesigning build.keychain
+      - name: Sign binary
+        run: |
+          IDENTITY=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application" | awk -F '"' '{print $2}' | head -1)
+          echo "Signing with: $IDENTITY"
+          codesign --sign "$IDENTITY" --options runtime --timestamp zig-out/bin/devswarm
+          codesign --verify --verbose zig-out/bin/devswarm
+      - name: Notarize
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          zip -j /tmp/devswarm-notarize.zip zig-out/bin/devswarm
+          xcrun notarytool submit /tmp/devswarm-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$TEAM_ID" \
+            --wait
       - name: Package
         run: |
           mkdir -p dist
           cp zig-out/bin/devswarm dist/${{ matrix.asset }}
           cd dist && shasum -a 256 ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
-
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
@@ -85,7 +111,6 @@ jobs:
         with:
           merge-multiple: true
           path: dist/
-
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -98,12 +123,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
           path: npm/bin/
-
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes the 'no identity found' error by properly setting up the keychain and resolving the signing identity dynamically.