### PR TITLE
ci: use apple-actions/import-codesign-certs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,21 +59,10 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} -Dversion="$VERSION"
       - name: Import signing certificate
-        env:
-          CERT_B64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT }}
-          CERT_PASS: ${{ secrets.APPLE_CERT_PASSWORD }}
-        run: |
-          echo "$CERT_B64" | base64 --decode > /tmp/cert.p12
-          KEYCHAIN_PASS=$(openssl rand -hex 16)
-          security create-keychain -p "$KEYCHAIN_PASS" build.keychain
-          security list-keychains -d user -s build.keychain $(security list-keychains -d user | tr -d '"')
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PASS" build.keychain
-          security set-keychain-settings -t 3600 -u build.keychain
-          security import /tmp/cert.p12 -k build.keychain -P "$CERT_PASS" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" build.keychain
-          rm /tmp/cert.p12
-          security find-identity -v -p codesigning build.keychain
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT }}
+          p12-password: ${{ secrets.APPLE_CERT_PASSWORD }}
       - name: Sign binary
         run: |
           IDENTITY=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application" | awk -F '"' '{print $2}' | head -1)


### PR DESCRIPTION
Fixes persistent MAC verification failures by using the official Apple codesign import action.