### PR TITLE
fix: 12+ modules with 250+ tests silently skipped by `zig build test` (missing comptime references)

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "devswarm": {
+      "type": "local",
+      "command": ["/Users/limyuxi/devswarm/zig-out/bin/devswarm", "--mcp"],
+      "environment": {
+        "REPO_PATH": "/Users/limyuxi/devswarm"
+      },
+      "enabled": true
+    }
+  }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -918,4 +918,16 @@ test "protocol: writeResult emits valid JSON-RPC 2.0 result structure" {
 comptime {
     _ = runtime;
     _ = @import("telemetry.zig");
+    _ = @import("auth.zig");
+    _ = @import("rate_limit.zig");
+    _ = @import("graph/edge_weights.zig");
+    _ = @import("graph/watcher.zig");
+    _ = @import("graph/hot_cache.zig");
+    _ = @import("graph/harness.zig");
+    _ = @import("graph/tenant.zig");
+    _ = @import("graph/ingest.zig");
+    _ = @import("graph/monorepo.zig");
+    _ = @import("graph/tier_manager.zig");
+    _ = @import("graph/wal.zig");
+    _ = @import("graph/ppr_incremental.zig");
 }


### PR DESCRIPTION
## Problem

The test binary is rooted at `src/main.zig` (via `exe.root_module`). Only modules transitively imported from `main.zig` have their tests discovered and run. The single `comptime { _ = runtime; }` block at `main.zig:907` only documents the pattern but does **not** cover the majority of modules.

The following modules with tests are **never reached** by `zig build test` because nothing in the import tree imports them:

| Module | Test count |
|---|---|
| `src/auth.zig` | 17 |
| `src/rate_limit.zig` | 22 |
| `src/graph/edge_weights.zig` | 29 |
| `src/graph/watcher.zig` | 14 |
| `src/graph/hot_cache.zig` | 21 |
| `src/graph/harness.zig` | 28 |
| `src/graph/ipc.zig` | 13 (via harness) |
| `src/graph/tenant.zig` | 29 |
| `src/graph/ingest.zig` | 22 |
| `src/graph/monorepo.zig` | 34 |
| `src/graph/tier_manager.zig` | 22 |
| `src/graph/wal.zig` | 21 |
| `src/graph/ppr_incremental.zig` | 20 |

**~272+ tests are silently never executed.**  CI shows green, but entire subsystems (auth, rate-limiting, graph ingestion, WAL, tenant management, etc.) have zero test coverage.

## Fix

Extend the `comptime` block in `main.zig` (line 907) to reference all orphaned modules:

```zig
comptime {
    _ = runtime;
    _ = @import("auth.zig");
    _ = @import("rate_limit.zig");
    _ = @import("graph/edge_weights.zig");
    _ = @import("graph/watcher.zig");
    _ = @import("graph/hot_cache.zig");
    _ = @import("graph/harness.zig");  // pulls in ipc.zig transitively
    _ = @import("graph/tenant.zig");
    _ = @import("graph/ingest.zig");
    _ = @import("graph/monorepo.zig");
    _ = @import("graph/tier_manager.zig");
    _ = @import("graph/wal.zig");
    _ = @import("graph/ppr_incremental.zig");
}
```

Verify with `zig build test 2>&1 | grep -c 'test '` — count should jump from ~130 to ~400+.

## Acceptance
- `zig build test` runs tests from all 13 listed modules
- CI stays green

Closes #310