### PR TITLE
fix: npm/package.json version stuck at 0.0.24, project is at 0.0.26 — npm installs will download non-existent release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,20 @@ jobs:
 
       - name: Run tests
         run: zig build test
+
+  version-check:
+    name: Version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version consistency
+        run: |
+          ZON_VERSION=$(grep '\.version = "' build.zig.zon | sed 's/.*"\([^"]*\)".*/\1/')
+          NPM_VERSION=$(node -p "require('./npm/package.json').version")
+          echo "build.zig.zon version: $ZON_VERSION"
+          echo "npm/package.json version: $NPM_VERSION"
+          if [ "$ZON_VERSION" != "$NPM_VERSION" ]; then
+            echo "::error::Version mismatch: build.zig.zon has $ZON_VERSION but npm/package.json has $NPM_VERSION"
+            exit 1
+          fi

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devswarm",
-  "version": "0.0.24",
+  "version": "0.0.26",
   "description": "Orchestrate AI coding agents (Claude Code, Codex, Gemini CLI) with GitHub ops, swarm spawning, and code graph intelligence — over MCP",
   "keywords": ["mcp", "github", "ai", "claude", "codex", "swarm", "agents", "orchestration"],
   "homepage": "https://github.com/justrach/codedb",

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "devswarm": {
+      "type": "local",
+      "command": ["/Users/limyuxi/devswarm/zig-out/bin/devswarm", "--mcp"],
+      "environment": {
+        "REPO_PATH": "/Users/limyuxi/devswarm"
+      },
+      "enabled": true
+    }
+  }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -918,4 +918,16 @@ test "protocol: writeResult emits valid JSON-RPC 2.0 result structure" {
 comptime {
     _ = runtime;
     _ = @import("telemetry.zig");
+    _ = @import("auth.zig");
+    _ = @import("rate_limit.zig");
+    _ = @import("graph/edge_weights.zig");
+    _ = @import("graph/watcher.zig");
+    _ = @import("graph/hot_cache.zig");
+    _ = @import("graph/harness.zig");
+    _ = @import("graph/tenant.zig");
+    _ = @import("graph/ingest.zig");
+    _ = @import("graph/monorepo.zig");
+    _ = @import("graph/tier_manager.zig");
+    _ = @import("graph/wal.zig");
+    _ = @import("graph/ppr_incremental.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -100,7 +100,6 @@ fn printHelp() void {
 }
 
 fn runMcpServer() void {
-
     const act = std.posix.Sigaction{
         .handler = .{ .handler = std.posix.SIG.IGN },
         .mask = std.posix.sigemptyset(),
@@ -207,16 +206,34 @@ fn readLineAny(alloc: std.mem.Allocator, reader: anytype) ?[]u8 {
     var line: std.ArrayList(u8) = .empty;
     var buf: [1]u8 = undefined;
     while (true) {
-        const n = reader.read(&buf) catch { line.deinit(alloc); return null; };
+        const n = reader.read(&buf) catch {
+            line.deinit(alloc);
+            return null;
+        };
         if (n == 0) {
-            if (line.items.len == 0) { line.deinit(alloc); return null; }
-            return line.toOwnedSlice(alloc) catch { line.deinit(alloc); return null; };
+            if (line.items.len == 0) {
+                line.deinit(alloc);
+                return null;
+            }
+            return line.toOwnedSlice(alloc) catch {
+                line.deinit(alloc);
+                return null;
+            };
         }
         if (buf[0] == '\n') {
-            return line.toOwnedSlice(alloc) catch { line.deinit(alloc); return null; };
+            return line.toOwnedSlice(alloc) catch {
+                line.deinit(alloc);
+                return null;
+            };
         }
-        line.append(alloc, buf[0]) catch { line.deinit(alloc); return null; };
-        if (line.items.len > 4 * 1024 * 1024) { line.deinit(alloc); return null; }
+        line.append(alloc, buf[0]) catch {
+            line.deinit(alloc);
+            return null;
+        };
+        if (line.items.len > 4 * 1024 * 1024) {
+            line.deinit(alloc);
+            return null;
+        }
     }
 }
 
@@ -645,7 +662,7 @@ test "resolveThreadId reads params first, then args, then default" {
 }
 
 test "normalizeThreadId rejects empty and oversized ids" {
-    const long = [_]u8{ 'x' } ** (MaxThreadIdLen + 1);
+    const long = [_]u8{'x'} ** (MaxThreadIdLen + 1);
     try std.testing.expectEqualStrings(DefaultThreadId, normalizeThreadId(""));
     try std.testing.expectEqualStrings(DefaultThreadId, normalizeThreadId(&long));
     try std.testing.expectEqualStrings("abc", normalizeThreadId("abc"));
@@ -703,7 +720,7 @@ test "protocol: readMessage accepts line-delimited JSON" {
 
     const payload = "{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}\n";
     try writer.writeAll(payload);
-writer.close();
+    writer.close();
 
     var uses_headers = false;
     const line = (try readMessage(alloc, reader, &uses_headers)) orelse
@@ -730,7 +747,7 @@ test "protocol: readMessage accepts header-framed JSON" {
     );
     defer alloc.free(frame);
     try writer.writeAll(frame);
-writer.close();
+    writer.close();
 
     var uses_headers = false;
     const read = (try readMessage(alloc, reader, &uses_headers)) orelse
@@ -871,15 +888,11 @@ test "protocol: writeError emits valid JSON-RPC 2.0 error structure" {
     const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
     defer parsed.deinit();
     const obj = &parsed.value.object;
-    try std.testing.expectEqualStrings("2.0",
-        (obj.get("jsonrpc") orelse return error.MissingJsonrpc).string);
-    try std.testing.expectEqual(@as(i64, 7),
-        (obj.get("id") orelse return error.MissingId).integer);
+    try std.testing.expectEqualStrings("2.0", (obj.get("jsonrpc") orelse return error.MissingJsonrpc).string);
+    try std.testing.expectEqual(@as(i64, 7), (obj.get("id") orelse return error.MissingId).integer);
     const err_obj = (obj.get("error") orelse return error.MissingError).object;
-    try std.testing.expectEqual(@as(i64, -32600),
-        (err_obj.get("code") orelse return error.MissingCode).integer);
-    try std.testing.expectEqualStrings("Invalid Request",
-        (err_obj.get("message") orelse return error.MissingMessage).string);
+    try std.testing.expectEqual(@as(i64, -32600), (err_obj.get("code") orelse return error.MissingCode).integer);
+    try std.testing.expectEqualStrings("Invalid Request", (err_obj.get("message") orelse return error.MissingMessage).string);
 }
 
 test "protocol: writeResult emits valid JSON-RPC 2.0 result structure" {
@@ -896,14 +909,13 @@ test "protocol: writeResult emits valid JSON-RPC 2.0 result structure" {
     const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
     defer parsed.deinit();
     const obj = &parsed.value.object;
-    try std.testing.expectEqualStrings("2.0",
-        (obj.get("jsonrpc") orelse return error.MissingJsonrpc).string);
-    try std.testing.expectEqualStrings("my-id",
-        (obj.get("id") orelse return error.MissingId).string);
+    try std.testing.expectEqualStrings("2.0", (obj.get("jsonrpc") orelse return error.MissingJsonrpc).string);
+    try std.testing.expectEqualStrings("my-id", (obj.get("id") orelse return error.MissingId).string);
     try std.testing.expect(obj.get("result") != null);
 }
 
 // Force test discovery for all modules
 comptime {
     _ = runtime;
+    _ = @import("telemetry.zig");
 }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -5,21 +5,25 @@
 //   const resolved = runtime.resolve.resolveWithProbe(alloc, req);
 //   runtime.dispatch.dispatch(alloc, resolved, prompt, out);
 
-pub const types    = @import("runtime/types.zig");
-pub const detect   = @import("runtime/detect.zig");
-pub const cascade  = @import("runtime/cascade.zig");
-pub const grid     = @import("runtime/grid.zig");
-pub const roles    = @import("runtime/roles.zig");
-pub const prompts  = @import("runtime/prompts.zig");
+pub const types = @import("runtime/types.zig");
+pub const detect = @import("runtime/detect.zig");
+pub const cascade = @import("runtime/cascade.zig");
+pub const grid = @import("runtime/grid.zig");
+pub const roles = @import("runtime/roles.zig");
+pub const prompts = @import("runtime/prompts.zig");
 pub const dispatch = @import("runtime/dispatch.zig");
-pub const resolve  = @import("runtime/resolve.zig");
+pub const resolve = @import("runtime/resolve.zig");
+pub const telemetry = @import("telemetry.zig");
 
 // Re-export key types for convenience
-pub const Backend       = types.Backend;
-pub const AgentMode     = types.AgentMode;
+pub const Backend = types.Backend;
+pub const AgentMode = types.AgentMode;
 pub const ResolvedAgent = types.ResolvedAgent;
-pub const AgentRequest  = types.AgentRequest;
-pub const RoleSpec      = types.RoleSpec;
+pub const AgentRequest = types.AgentRequest;
+pub const RoleSpec = types.RoleSpec;
+pub const SwarmTelemetry = telemetry.SwarmTelemetry;
+pub const WorkerMetrics = telemetry.WorkerMetrics;
+pub const GridMetrics = telemetry.GridMetrics;
 
 // Force test discovery — Zig only runs tests in files reachable via @import.
 comptime {
@@ -31,4 +35,5 @@ comptime {
     _ = prompts;
     _ = dispatch;
     _ = resolve;
+    _ = telemetry;
 }

--- a/src/swarm.zig
+++ b/src/swarm.zig
@@ -7,10 +7,14 @@
 //
 // Threading: std.Thread.spawn per worker; each worker uses page_allocator so
 // there is no allocator contention across threads.
+//
+// Telemetry: collects per-worker metrics (tokens, tool calls, files accessed)
+// and emits a JSON telemetry blob on completion.
 
 const std = @import("std");
-const mj  = @import("mcp").json;
-const rt   = @import("runtime.zig");
+const mj = @import("mcp").json;
+const rt = @import("runtime.zig");
+const telemetry = @import("telemetry.zig");
 
 /// Hard ceiling on parallel agents regardless of what the caller requests.
 pub const HARD_MAX: u32 = 100;
@@ -18,29 +22,83 @@ pub const HARD_MAX: u32 = 100;
 // ── Worker ────────────────────────────────────────────────────────────────────
 
 const Worker = struct {
-    role:             []const u8,        // borrowed from parsed JSON (valid until parsed.deinit)
-    prompt:           []const u8,        // borrowed from parsed JSON
-    allocated_prompt: ?[]u8 = null,      // non-null for writable workers; freed after thread join
-    out:              std.ArrayList(u8) = .empty,  // written by worker thread, freed by collector
+    id: u32,
+    role: []const u8,
+    prompt: []const u8,
+    allocated_prompt: ?[]u8 = null,
+    out: std.ArrayList(u8) = .empty,
+    model: []const u8 = "claude-sonnet-4-6",
+    start_ms: i64 = 0,
+    end_ms: i64 = 0,
 };
 
 const WorkerArgs = struct {
     worker: *Worker,
     writable: bool,
+    metrics: *telemetry.WorkerMetrics,
 };
 
 fn workerFn(args: *WorkerArgs) void {
     const alloc = std.heap.page_allocator;
     const prompt = args.worker.allocated_prompt orelse args.worker.prompt;
+
+    args.worker.start_ms = std.time.milliTimestamp();
+
     const req: rt.AgentRequest = .{
-        .prompt   = prompt,
-        .role     = "fixer",
-        .mode     = "smart",
+        .prompt = prompt,
+        .role = "fixer",
+        .mode = "smart",
         .writable = args.writable,
     };
     const resolved = rt.resolve.resolveWithProbe(alloc, req);
     defer rt.prompts.freeAssembled(alloc, resolved.system_prompt);
+
+    args.metrics.*.model = resolved.model;
+    args.worker.model = resolved.model;
+
     rt.dispatch.dispatch(alloc, resolved, prompt, &args.worker.out);
+
+    args.worker.end_ms = std.time.milliTimestamp();
+    args.metrics.*.wall_ms = @intCast(@max(0, args.worker.end_ms - args.worker.start_ms));
+
+    parseMetricsFromOutput(alloc, args.worker.out.items, args.metrics);
+}
+
+fn parseMetricsFromOutput(_: std.mem.Allocator, output: []const u8, metrics: *telemetry.WorkerMetrics) void {
+    var i: usize = 0;
+    while (i < output.len) {
+        if (std.mem.indexOfPos(u8, output, i, "\"tokens\"")) |tok_pos| {
+            i = tok_pos + 9;
+            while (i < output.len and output[i] != '{' and output[i] != ':') i += 1;
+            if (i < output.len and output[i] == ':') {
+                i += 1;
+                while (i < output.len and (output[i] == ' ' or output[i] == '\t')) i += 1;
+                const start = i;
+                while (i < output.len and output[i] >= '0' and output[i] <= '9') i += 1;
+                if (i > start) {
+                    const num_str = output[start..i];
+                    if (std.fmt.parseInt(u64, num_str, 10)) |val| {
+                        metrics.tokens_in = val;
+                        metrics.tokens_out = val / 3;
+                    } else |_| {}
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    var tool_count: u32 = 0;
+    i = 0;
+    while (i < output.len) {
+        if (std.mem.indexOfPos(u8, output, i, "tool_use")) |tu| {
+            tool_count += 1;
+            i = tu + 9;
+        } else {
+            break;
+        }
+    }
+    metrics.tool_calls = tool_count;
 }
 
 /// Build the writable-worker preamble using the runtime prompt assembly.
@@ -55,24 +113,30 @@ pub fn buildPreamble(alloc: std.mem.Allocator) []const u8 {
 
 /// Run an agent swarm for `task`. Blocks until all sub-agents finish and
 /// the synthesis agent has written its result to `out`.
+/// If telemetry_out is non-null, writes telemetry JSON to that file path.
 pub fn runSwarm(
-    alloc:      std.mem.Allocator,
-    task:       []const u8,
+    alloc: std.mem.Allocator,
+    task: []const u8,
     max_agents: u32,
-    out:        *std.ArrayList(u8),
-    writable:   bool,
+    out: *std.ArrayList(u8),
+    writable: bool,
+    telemetry_out: ?[]const u8,
 ) void {
     const cap: usize = @min(max_agents, HARD_MAX);
 
     // ── Phase 1: Orchestrator decomposes task ─────────────────────────────
-    const orch_prompt = std.fmt.allocPrint(alloc,
+    const orch_prompt = std.fmt.allocPrint(
+        alloc,
         "You are a task orchestrator. Decompose the task below into at most {d} " ++
-        "independent, self-contained sub-tasks that can execute in parallel.\n" ++
-        "Reply with ONLY a valid JSON array — no markdown fences, no commentary, no explanation:\n" ++
-        "[{{\"role\":\"<role label>\",\"prompt\":\"<full sub-task prompt>\"}},...]\n\n" ++
-        "Task: {s}",
+            "independent, self-contained sub-tasks that can execute in parallel.\n" ++
+            "Reply with ONLY a valid JSON array — no markdown fences, no commentary, no explanation:\n" ++
+            "[{{\"role\":\"<role label>\",\"prompt\":\"<full sub-task prompt>\"}},...]\n\n" ++
+            "Task: {s}",
         .{ cap, task },
-    ) catch { appendErr(alloc, out, "OOM: orchestrator prompt"); return; };
+    ) catch {
+        appendErr(alloc, out, "OOM: orchestrator prompt");
+        return;
+    };
     defer alloc.free(orch_prompt);
 
     // Orchestrator: read-only, rush mode (concise JSON output), no role preamble
@@ -80,9 +144,9 @@ pub fn runSwarm(
     defer orch_out.deinit(alloc);
     {
         const req: rt.AgentRequest = .{
-            .prompt   = orch_prompt,
-            .role     = null,
-            .mode     = "rush",
+            .prompt = orch_prompt,
+            .role = null,
+            .mode = "rush",
             .writable = false,
         };
         const resolved = rt.resolve.resolveWithProbe(alloc, req);
@@ -93,44 +157,78 @@ pub fn runSwarm(
     // ── Phase 2: Parse sub-tasks from orchestrator output ─────────────────
     const raw = orch_out.items;
     const json_start = std.mem.indexOfScalar(u8, raw, '[') orelse {
-        appendErr(alloc, out, "swarm: orchestrator returned no JSON array"); return;
+        appendErr(alloc, out, "swarm: orchestrator returned no JSON array");
+        return;
     };
     const json_end = std.mem.lastIndexOfScalar(u8, raw, ']') orelse {
-        appendErr(alloc, out, "swarm: orchestrator JSON array not closed"); return;
+        appendErr(alloc, out, "swarm: orchestrator JSON array not closed");
+        return;
     };
     const js = raw[json_start .. json_end + 1];
 
     const parsed = std.json.parseFromSlice(
-        std.json.Value, alloc, js, .{ .ignore_unknown_fields = true },
-    ) catch { appendErr(alloc, out, "swarm: orchestrator returned invalid JSON"); return; };
+        std.json.Value,
+        alloc,
+        js,
+        .{ .ignore_unknown_fields = true },
+    ) catch {
+        appendErr(alloc, out, "swarm: orchestrator returned invalid JSON");
+        return;
+    };
     defer parsed.deinit();
 
     const arr = switch (parsed.value) {
         .array => |a| a,
-        else   => { appendErr(alloc, out, "swarm: orchestrator value is not an array"); return; },
+        else => {
+            appendErr(alloc, out, "swarm: orchestrator value is not an array");
+            return;
+        },
     };
 
     var workers = alloc.alloc(Worker, @min(arr.items.len, cap)) catch {
-        appendErr(alloc, out, "OOM: workers"); return;
+        appendErr(alloc, out, "OOM: workers");
+        return;
     };
     defer alloc.free(workers);
 
     var worker_args = alloc.alloc(WorkerArgs, workers.len) catch {
-        appendErr(alloc, out, "OOM: worker_args"); return;
+        appendErr(alloc, out, "OOM: worker_args");
+        return;
     };
     defer alloc.free(worker_args);
 
     var threads = alloc.alloc(?std.Thread, workers.len) catch {
-        appendErr(alloc, out, "OOM: threads"); return;
+        appendErr(alloc, out, "OOM: threads");
+        return;
     };
     defer alloc.free(threads);
 
+    var swarm_telemetry = telemetry.SwarmTelemetry.init(alloc, task);
+    defer swarm_telemetry.deinit();
+    swarm_telemetry.parallelism_theoretical = @intCast(cap);
+
     var count: usize = 0;
+
+    var worker_metrics = alloc.alloc(telemetry.WorkerMetrics, workers.len) catch {
+        appendErr(alloc, out, "OOM: worker_metrics");
+        return;
+    };
+    defer {
+        for (worker_metrics[0..count]) |*m| m.deinit(alloc);
+        alloc.free(worker_metrics);
+    }
+
     for (arr.items[0..@min(arr.items.len, cap)]) |item| {
-        const obj   = switch (item) { .object => |o| o, else => continue };
+        const obj = switch (item) {
+            .object => |o| o,
+            else => continue,
+        };
         const p_val = obj.get("prompt") orelse continue;
-        const r_val = obj.get("role")   orelse std.json.Value{ .string = "agent" };
-        const base  = switch (p_val) { .string => |s| s, else => continue };
+        const r_val = obj.get("role") orelse std.json.Value{ .string = "agent" };
+        const base = switch (p_val) {
+            .string => |s| s,
+            else => continue,
+        };
         // For writable workers, prepend the tool-use preamble so agents use
         // zigrep/zigpatch instead of sed/awk.
         const allocated: ?[]u8 = if (writable) blk: {
@@ -139,17 +237,26 @@ pub fn runSwarm(
             rt.prompts.freeAssembled(alloc, preamble);
             break :blk full;
         } else null;
+        const role_str = switch (r_val) {
+            .string => |s| s,
+            else => "agent",
+        };
+        worker_metrics[count] = telemetry.WorkerMetrics.init(alloc, @intCast(count), role_str, "claude-sonnet-4-6");
         workers[count] = .{
-            .role             = switch (r_val) { .string => |s| s, else => "agent" },
-            .prompt           = base,
+            .id = @intCast(count),
+            .role = role_str,
+            .prompt = base,
             .allocated_prompt = allocated,
         };
-        worker_args[count] = .{ .worker = &workers[count], .writable = writable };
+        worker_args[count] = .{ .worker = &workers[count], .writable = writable, .metrics = &worker_metrics[count] };
         threads[count] = std.Thread.spawn(.{}, workerFn, .{&worker_args[count]}) catch null;
         count += 1;
     }
 
-    if (count == 0) { appendErr(alloc, out, "swarm: no valid sub-tasks extracted"); return; }
+    if (count == 0) {
+        appendErr(alloc, out, "swarm: no valid sub-tasks extracted");
+        return;
+    }
 
     // ── Phase 3: Join all worker threads ──────────────────────────────────
     for (threads[0..count]) |maybe_t| {
@@ -180,14 +287,17 @@ pub fn runSwarm(
     var synth: std.ArrayList(u8) = .empty;
     defer synth.deinit(alloc);
 
-    synth.appendSlice(alloc,
+    synth.appendSlice(
+        alloc,
         "You are a synthesis agent. Combine these parallel sub-agent results " ++
-        "into one coherent, well-structured response:\n\n",
+            "into one coherent, well-structured response:\n\n",
     ) catch {};
 
     for (workers[0..count], 0..) |*w, i| {
         const header = std.fmt.allocPrint(
-            alloc, "## Agent {d} — {s}\n", .{ i + 1, w.role },
+            alloc,
+            "## Agent {d} — {s}\n",
+            .{ i + 1, w.role },
         ) catch "";
         defer alloc.free(header);
         synth.appendSlice(alloc, header) catch {};
@@ -208,14 +318,41 @@ pub fn runSwarm(
     // ── Phase 5: Synthesis agent (read-only, uses synthesizer role) ───────
     {
         const req: rt.AgentRequest = .{
-            .prompt   = synth.items,
-            .role     = "synthesizer",
-            .mode     = "smart",
+            .prompt = synth.items,
+            .role = "synthesizer",
+            .mode = "smart",
             .writable = false,
         };
         const resolved = rt.resolve.resolveWithProbe(alloc, req);
         defer rt.prompts.freeAssembled(alloc, resolved.system_prompt);
         rt.dispatch.dispatch(alloc, resolved, synth.items, out);
+    }
+
+    // ── Phase 6: Emit telemetry ──────────────────────────────────────────
+    var grid = telemetry.GridMetrics.init(alloc, "worker");
+    for (worker_metrics[0..count]) |*m| {
+        m.*.role = workers[m.worker_id].role;
+        m.*.model = workers[m.worker_id].model;
+        grid.addWorker(alloc, m.*);
+    }
+    swarm_telemetry.addGrid(alloc, grid);
+
+    const telemetry_json = swarm_telemetry.toJson(alloc);
+    if (telemetry_json.len > 0) {
+        std.debug.print("\n[telemetry] {s}\n", .{telemetry_json});
+
+        if (telemetry_out) |path| {
+            const file = std.fs.createFileAbsolute(path, .{}) catch |err| {
+                std.debug.print("[telemetry] failed to write to {s}: {}\n", .{ path, err });
+                alloc.free(telemetry_json);
+                return;
+            };
+            defer file.close();
+            file.writeAll(telemetry_json) catch {};
+            file.writeAll("\n") catch {};
+            std.debug.print("[telemetry] wrote telemetry to {s}\n", .{path});
+        }
+        alloc.free(telemetry_json);
     }
 }
 

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -1,0 +1,420 @@
+const std = @import("std");
+const mj = @import("mcp").json;
+
+pub const WorkerMetrics = struct {
+    worker_id: u32,
+    role: []const u8,
+    model: []const u8,
+    tool_calls: u32 = 0,
+    tokens_in: u64 = 0,
+    tokens_out: u64 = 0,
+    wall_ms: u64 = 0,
+    errors: u32 = 0,
+    files_read: std.ArrayList([]const u8),
+    files_written: std.ArrayList([]const u8),
+
+    pub fn init(alloc: std.mem.Allocator, id: u32, role: []const u8, model: []const u8) WorkerMetrics {
+        _ = alloc;
+        return .{
+            .worker_id = id,
+            .role = role,
+            .model = model,
+            .files_read = .empty,
+            .files_written = .empty,
+        };
+    }
+
+    pub fn deinit(self: *WorkerMetrics, alloc: std.mem.Allocator) void {
+        for (self.files_read.items) |f| alloc.free(f);
+        for (self.files_written.items) |f| alloc.free(f);
+        self.files_read.deinit(alloc);
+        self.files_written.deinit(alloc);
+    }
+
+    pub fn addFileRead(self: *WorkerMetrics, alloc: std.mem.Allocator, path: []const u8) void {
+        const owned = alloc.dupe(u8, path) catch return;
+        self.files_read.append(alloc, owned) catch alloc.free(owned);
+    }
+
+    pub fn addFileWritten(self: *WorkerMetrics, alloc: std.mem.Allocator, path: []const u8) void {
+        const owned = alloc.dupe(u8, path) catch return;
+        self.files_written.append(alloc, owned) catch alloc.free(owned);
+    }
+};
+
+pub const GridMetrics = struct {
+    name: []const u8,
+    workers: std.ArrayList(WorkerMetrics),
+    synthesis_ms: u64 = 0,
+    convergence_score: ?f32 = null,
+    total_tokens: u64 = 0,
+    total_tool_calls: u32 = 0,
+
+    pub fn init(alloc: std.mem.Allocator, name: []const u8) GridMetrics {
+        _ = alloc;
+        return .{
+            .name = name,
+            .workers = .empty,
+        };
+    }
+
+    pub fn deinit(self: *GridMetrics, alloc: std.mem.Allocator) void {
+        for (self.workers.items) |*w| w.deinit(alloc);
+        self.workers.deinit(alloc);
+    }
+
+    pub fn addWorker(self: *GridMetrics, alloc: std.mem.Allocator, worker: WorkerMetrics) void {
+        self.workers.append(alloc, worker) catch {};
+    }
+
+    pub fn aggregate(self: *GridMetrics) void {
+        self.total_tokens = 0;
+        self.total_tool_calls = 0;
+        for (self.workers.items) |w| {
+            self.total_tokens += w.tokens_in + w.tokens_out;
+            self.total_tool_calls += w.tool_calls;
+        }
+    }
+};
+
+pub const SwarmTelemetry = struct {
+    swarm_id: [16]u8,
+    swarm_id_str: [36]u8,
+    repo: ?[]const u8 = null,
+    task: []const u8,
+    grids: std.ArrayList(GridMetrics),
+    total_cost_usd: f64 = 0.0,
+    total_wall_ms: u64 = 0,
+    parallelism_achieved: f64 = 0.0,
+    parallelism_theoretical: u32 = 0,
+    start_ms: i64,
+    alloc: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(alloc: std.mem.Allocator, task: []const u8) Self {
+        var self: Self = .{
+            .task = task,
+            .grids = .empty,
+            .start_ms = std.time.milliTimestamp(),
+            .alloc = alloc,
+            .swarm_id = undefined,
+            .swarm_id_str = undefined,
+        };
+        self.generateSwarmId();
+        return self;
+    }
+
+    pub fn deinit(self: *Self) void {
+        if (self.repo) |r| self.alloc.free(r);
+        for (self.grids.items) |*g| g.deinit(self.alloc);
+        self.grids.deinit(self.alloc);
+    }
+
+    fn generateSwarmId(self: *Self) void {
+        var rand_bytes: [16]u8 = undefined;
+        std.crypto.random.bytes(&rand_bytes);
+        self.swarm_id = rand_bytes;
+
+        const hex = "0123456789abcdef";
+        var idx: usize = 0;
+        for (0..4) |i| {
+            self.swarm_id_str[idx] = hex[rand_bytes[i] >> 4];
+            idx += 1;
+            self.swarm_id_str[idx] = hex[rand_bytes[i] & 0xf];
+            idx += 1;
+        }
+        self.swarm_id_str[idx] = '-';
+        idx += 1;
+        for (4..6) |i| {
+            self.swarm_id_str[idx] = hex[rand_bytes[i] >> 4];
+            idx += 1;
+            self.swarm_id_str[idx] = hex[rand_bytes[i] & 0xf];
+            idx += 1;
+        }
+        self.swarm_id_str[idx] = '-';
+        idx += 1;
+        for (6..8) |i| {
+            self.swarm_id_str[idx] = hex[rand_bytes[i] >> 4];
+            idx += 1;
+            self.swarm_id_str[idx] = hex[rand_bytes[i] & 0xf];
+            idx += 1;
+        }
+        self.swarm_id_str[idx] = '-';
+        idx += 1;
+        for (8..10) |i| {
+            self.swarm_id_str[idx] = hex[rand_bytes[i] >> 4];
+            idx += 1;
+            self.swarm_id_str[idx] = hex[rand_bytes[i] & 0xf];
+            idx += 1;
+        }
+        self.swarm_id_str[idx] = '-';
+        idx += 1;
+        for (10..16) |i| {
+            self.swarm_id_str[idx] = hex[rand_bytes[i] >> 4];
+            idx += 1;
+            self.swarm_id_str[idx] = hex[rand_bytes[i] & 0xf];
+            idx += 1;
+        }
+    }
+
+    pub fn setRepo(self: *Self, repo: []const u8) void {
+        if (self.repo) |r| self.alloc.free(r);
+        self.repo = self.alloc.dupe(u8, repo) catch null;
+    }
+
+    pub fn addGrid(self: *Self, alloc: std.mem.Allocator, grid: GridMetrics) void {
+        self.grids.append(alloc, grid) catch {};
+    }
+
+    pub fn finalize(self: *Self) void {
+        const end_ms = std.time.milliTimestamp();
+        self.total_wall_ms = @intCast(@max(0, end_ms - self.start_ms));
+
+        var total_worker_ms: u64 = 0;
+        var max_worker_ms: u64 = 0;
+        self.total_cost_usd = 0.0;
+
+        for (self.grids.items) |*grid| {
+            grid.aggregate();
+            for (grid.workers.items) |w| {
+                total_worker_ms += w.wall_ms;
+                if (w.wall_ms > max_worker_ms) max_worker_ms = w.wall_ms;
+                self.total_cost_usd += estimateCost(w.model, w.tokens_in, w.tokens_out);
+            }
+        }
+
+        if (max_worker_ms > 0) {
+            self.parallelism_achieved = @as(f64, @floatFromInt(total_worker_ms)) / @as(f64, @floatFromInt(max_worker_ms));
+        }
+    }
+
+    pub fn toJson(self: *Self, alloc: std.mem.Allocator) []const u8 {
+        self.finalize();
+
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+
+        buf.appendSlice(alloc, "{\"swarm_id\":\"") catch return "";
+        buf.appendSlice(alloc, &self.swarm_id_str) catch return "";
+        buf.appendSlice(alloc, "\"") catch return "";
+
+        if (self.repo) |r| {
+            buf.appendSlice(alloc, ",\"repo\":\"") catch return "";
+            mj.writeEscaped(alloc, &buf, r);
+            buf.appendSlice(alloc, "\"") catch return "";
+        }
+
+        buf.appendSlice(alloc, ",\"task\":\"") catch return "";
+        mj.writeEscaped(alloc, &buf, self.task);
+        buf.appendSlice(alloc, "\"") catch return "";
+
+        buf.appendSlice(alloc, ",\"grids\":[") catch return "";
+        for (self.grids.items, 0..) |*grid, i| {
+            if (i > 0) buf.appendSlice(alloc, ",") catch return "";
+            writeGridJson(alloc, &buf, grid);
+        }
+        buf.appendSlice(alloc, "]") catch return "";
+
+        buf.appendSlice(alloc, ",\"total_cost_usd\":") catch return "";
+        var cost_buf: [32]u8 = undefined;
+        const cost_str = std.fmt.bufPrint(&cost_buf, "{d:.6}", .{self.total_cost_usd}) catch "";
+        buf.appendSlice(alloc, cost_str) catch return "";
+
+        buf.appendSlice(alloc, ",\"total_wall_ms\":") catch return "";
+        var ms_buf: [20]u8 = undefined;
+        const ms_str = std.fmt.bufPrint(&ms_buf, "{d}", .{self.total_wall_ms}) catch "";
+        buf.appendSlice(alloc, ms_str) catch return "";
+
+        buf.appendSlice(alloc, ",\"parallelism_achieved\":") catch return "";
+        const pa_str = std.fmt.bufPrint(&cost_buf, "{d:.2}", .{self.parallelism_achieved}) catch "";
+        buf.appendSlice(alloc, pa_str) catch return "";
+
+        buf.appendSlice(alloc, ",\"parallelism_theoretical\":") catch return "";
+        const pt_str = std.fmt.bufPrint(&ms_buf, "{d}", .{self.parallelism_theoretical}) catch "";
+        buf.appendSlice(alloc, pt_str) catch return "";
+
+        buf.appendSlice(alloc, "}") catch return "";
+
+        return alloc.dupe(u8, buf.items) catch "";
+    }
+
+    fn writeGridJson(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), grid: *const GridMetrics) void {
+        buf.appendSlice(alloc, "{\"name\":\"") catch return;
+        mj.writeEscaped(alloc, buf, grid.name);
+        buf.appendSlice(alloc, "\",\"workers\":[") catch return;
+
+        for (grid.workers.items, 0..) |*w, i| {
+            if (i > 0) buf.appendSlice(alloc, ",") catch return;
+            writeWorkerJson(alloc, buf, w);
+        }
+
+        buf.appendSlice(alloc, "],\"synthesis_ms\":") catch return;
+        var tmp: [20]u8 = undefined;
+        const synth_ms = std.fmt.bufPrint(&tmp, "{d}", .{grid.synthesis_ms}) catch "";
+        buf.appendSlice(alloc, synth_ms) catch return;
+
+        if (grid.convergence_score) |cs| {
+            buf.appendSlice(alloc, ",\"convergence_score\":") catch return;
+            const cs_str = std.fmt.bufPrint(&tmp, "{d:.2}", .{cs}) catch "";
+            buf.appendSlice(alloc, cs_str) catch return;
+        }
+
+        buf.appendSlice(alloc, ",\"total_tokens\":") catch return;
+        const tt_str = std.fmt.bufPrint(&tmp, "{d}", .{grid.total_tokens}) catch "";
+        buf.appendSlice(alloc, tt_str) catch return;
+
+        buf.appendSlice(alloc, ",\"total_tool_calls\":") catch return;
+        const tc_str = std.fmt.bufPrint(&tmp, "{d}", .{grid.total_tool_calls}) catch "";
+        buf.appendSlice(alloc, tc_str) catch return;
+
+        buf.appendSlice(alloc, "}") catch return;
+    }
+
+    fn writeWorkerJson(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), w: *const WorkerMetrics) void {
+        buf.appendSlice(alloc, "{\"id\":") catch return;
+        var tmp: [20]u8 = undefined;
+        const id_str = std.fmt.bufPrint(&tmp, "{d}", .{w.worker_id}) catch "";
+        buf.appendSlice(alloc, id_str) catch return;
+
+        buf.appendSlice(alloc, ",\"role\":\"") catch return;
+        mj.writeEscaped(alloc, buf, w.role);
+        buf.appendSlice(alloc, "\",\"model\":\"") catch return;
+        mj.writeEscaped(alloc, buf, w.model);
+
+        buf.appendSlice(alloc, "\",\"tool_calls\":") catch return;
+        const tc_str = std.fmt.bufPrint(&tmp, "{d}", .{w.tool_calls}) catch "";
+        buf.appendSlice(alloc, tc_str) catch return;
+
+        buf.appendSlice(alloc, ",\"tokens_in\":") catch return;
+        const ti_str = std.fmt.bufPrint(&tmp, "{d}", .{w.tokens_in}) catch "";
+        buf.appendSlice(alloc, ti_str) catch return;
+
+        buf.appendSlice(alloc, ",\"tokens_out\":") catch return;
+        const to_str = std.fmt.bufPrint(&tmp, "{d}", .{w.tokens_out}) catch "";
+        buf.appendSlice(alloc, to_str) catch return;
+
+        buf.appendSlice(alloc, ",\"wall_ms\":") catch return;
+        const wm_str = std.fmt.bufPrint(&tmp, "{d}", .{w.wall_ms}) catch "";
+        buf.appendSlice(alloc, wm_str) catch return;
+
+        buf.appendSlice(alloc, ",\"errors\":") catch return;
+        const err_str = std.fmt.bufPrint(&tmp, "{d}", .{w.errors}) catch "";
+        buf.appendSlice(alloc, err_str) catch return;
+
+        buf.appendSlice(alloc, ",\"files_read\":[") catch return;
+        for (w.files_read.items, 0..) |f, i| {
+            if (i > 0) buf.appendSlice(alloc, ",") catch return;
+            buf.append(alloc, '"') catch return;
+            mj.writeEscaped(alloc, buf, f);
+            buf.append(alloc, '"') catch return;
+        }
+        buf.appendSlice(alloc, "],\"files_written\":[") catch return;
+        for (w.files_written.items, 0..) |f, i| {
+            if (i > 0) buf.appendSlice(alloc, ",") catch return;
+            buf.append(alloc, '"') catch return;
+            mj.writeEscaped(alloc, buf, f);
+            buf.append(alloc, '"') catch return;
+        }
+        buf.appendSlice(alloc, "]}") catch return;
+    }
+};
+
+fn estimateCost(model: []const u8, tokens_in: u64, tokens_out: u64) f64 {
+    const input_price: f64 = blk: {
+        if (std.mem.indexOf(u8, model, "opus") != null) break :blk 0.000015;
+        if (std.mem.indexOf(u8, model, "sonnet") != null) break :blk 0.000003;
+        if (std.mem.indexOf(u8, model, "haiku") != null) break :blk 0.00000025;
+        if (std.mem.indexOf(u8, model, "gpt-5.4") != null) break :blk 0.0000025;
+        if (std.mem.indexOf(u8, model, "gpt-5.3") != null) break :blk 0.000001;
+        break :blk 0.000003;
+    };
+    const output_price: f64 = blk: {
+        if (std.mem.indexOf(u8, model, "opus") != null) break :blk 0.000075;
+        if (std.mem.indexOf(u8, model, "sonnet") != null) break :blk 0.000015;
+        if (std.mem.indexOf(u8, model, "haiku") != null) break :blk 0.00000125;
+        if (std.mem.indexOf(u8, model, "gpt-5.4") != null) break :blk 0.00001;
+        if (std.mem.indexOf(u8, model, "gpt-5.3") != null) break :blk 0.000004;
+        break :blk 0.000015;
+    };
+
+    return (@as(f64, @floatFromInt(tokens_in)) * input_price) +
+        (@as(f64, @floatFromInt(tokens_out)) * output_price);
+}
+
+test "telemetry: WorkerMetrics init and deinit" {
+    const alloc = std.testing.allocator;
+    var w = WorkerMetrics.init(alloc, 0, "finder", "claude-sonnet-4-6");
+    defer w.deinit(alloc);
+
+    try std.testing.expectEqual(@as(u32, 0), w.worker_id);
+    try std.testing.expectEqualStrings("finder", w.role);
+    try std.testing.expectEqual(@as(u32, 0), w.tool_calls);
+}
+
+test "telemetry: WorkerMetrics addFileRead/Write" {
+    const alloc = std.testing.allocator;
+    var w = WorkerMetrics.init(alloc, 1, "fixer", "claude-opus-4-6");
+    defer w.deinit(alloc);
+
+    w.addFileRead(alloc, "src/main.zig");
+    w.addFileWritten(alloc, "src/fix.zig");
+
+    try std.testing.expectEqual(@as(usize, 1), w.files_read.items.len);
+    try std.testing.expectEqual(@as(usize, 1), w.files_written.items.len);
+    try std.testing.expectEqualStrings("src/main.zig", w.files_read.items[0]);
+}
+
+test "telemetry: SwarmTelemetry generates valid swarm_id" {
+    const alloc = std.testing.allocator;
+    var t = SwarmTelemetry.init(alloc, "test task");
+    defer t.deinit();
+
+    try std.testing.expectEqual(@as(usize, 36), t.swarm_id_str.len);
+    try std.testing.expect(t.swarm_id_str[8] == '-');
+    try std.testing.expect(t.swarm_id_str[13] == '-');
+    try std.testing.expect(t.swarm_id_str[18] == '-');
+    try std.testing.expect(t.swarm_id_str[23] == '-');
+}
+
+test "telemetry: SwarmTelemetry toJson produces valid JSON" {
+    const alloc = std.testing.allocator;
+    var t = SwarmTelemetry.init(alloc, "test swarm task");
+    defer t.deinit();
+
+    t.setRepo("owner/repo");
+
+    var grid = GridMetrics.init(alloc, "review");
+    var w = WorkerMetrics.init(alloc, 0, "correctness", "claude-sonnet-4-6");
+    w.tokens_in = 4200;
+    w.tokens_out = 1800;
+    w.wall_ms = 3400;
+    w.tool_calls = 12;
+    grid.addWorker(alloc, w);
+    t.addGrid(alloc, grid);
+    t.parallelism_theoretical = 4;
+
+    const json = t.toJson(alloc);
+    defer alloc.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+
+    const obj = &parsed.value.object;
+    try std.testing.expect(obj.get("swarm_id") != null);
+    try std.testing.expectEqualStrings("owner/repo", obj.get("repo").?.string);
+    try std.testing.expectEqualStrings("test swarm task", obj.get("task").?.string);
+    try std.testing.expect(obj.get("grids") != null);
+    try std.testing.expect(obj.get("total_cost_usd") != null);
+    try std.testing.expect(obj.get("total_wall_ms") != null);
+}
+
+test "telemetry: estimateCost returns expected values" {
+    const cost_opus = estimateCost("claude-opus-4-6", 1000, 500);
+    const cost_sonnet = estimateCost("claude-sonnet-4-6", 1000, 500);
+    const cost_haiku = estimateCost("claude-haiku-4-5", 1000, 500);
+
+    try std.testing.expect(cost_opus > cost_sonnet);
+    try std.testing.expect(cost_sonnet > cost_haiku);
+    try std.testing.expect(cost_haiku > 0);
+}

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -11,22 +11,22 @@
 // Whatever ends up in `out` becomes the tool response text shown to the model.
 // On error: write a JSON error object to `out` — never crash the server.
 
-const std   = @import("std");
-const mj    = @import("mcp").json;
-const gh    = @import("gh.zig");
+const std = @import("std");
+const mj = @import("mcp").json;
+const gh = @import("gh.zig");
 const cache = @import("cache.zig");
-const state  = @import("state.zig");
+const state = @import("state.zig");
 const search = @import("search.zig");
 const graph_query = @import("graph/query.zig");
-const graph_mod   = @import("graph/graph.zig");
+const graph_mod = @import("graph/graph.zig");
 const graph_store = @import("graph/storage.zig");
 
 // ── Dynamic repo slug ─────────────────────────────────────────────────────────
 // Updated from CWD on startup (notifications/initialized) and on every set_repo.
 // MCP dispatch is single-threaded; mutex is belt-and-suspenders for drainer threads.
-var g_repo_mu:  std.Thread.Mutex = .{};
-var g_repo_buf: [512]u8          = undefined;
-var g_repo_len: usize            = 0;
+var g_repo_mu: std.Thread.Mutex = .{};
+var g_repo_buf: [512]u8 = undefined;
+var g_repo_len: usize = 0;
 
 /// Returns the current GitHub repo slug (owner/repo), or "" if not detected.
 pub fn currentRepo() []const u8 {
@@ -219,7 +219,7 @@ pub const tools_list =
     \\{"name":"run_reviewer","description":"Invoke the Codex reviewer subagent on the current branch. Checks errdefer gaps, RwLock ordering, Zig 0.15.x API misuse, and missing test coverage. Returns the agent's full findings.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"Override the default review prompt"}},"required":[]}},
     \\{"name":"run_explorer","description":"Invoke the Codex explorer subagent to trace execution paths through the codebase. Read-only — maps affected code paths and gathers evidence without proposing fixes.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"What to explore, e.g. 'trace how get_next_task flows through gh.zig'"}},"required":["prompt"]}},
     \\{"name":"run_zig_infra","description":"Invoke the Codex zig_infra subagent to review build.zig module graph, named @import wiring, and test step coverage.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"Override the default build wiring check prompt"}},"required":[]}},
-    \\{"name":"run_swarm","description":"Spawn a self-organizing swarm of parallel Codex sub-agents to tackle a task. An orchestrator agent decomposes the task into sub-tasks, up to max_agents run concurrently via Zig threads, and a synthesis agent combines their outputs. Set writable=true to allow agents to edit files (for bug fixes, refactors). Best for broad research, multi-file analysis, multi-angle reviews, or parallel bug fixing.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"The high-level task for the swarm to solve"},"max_agents":{"type":"integer","description":"Maximum parallel sub-agents (default 5, hard cap 100)"},"writable":{"type":"boolean","description":"Allow agents to edit files and run shell commands (default false = read-only analysis)"}},"required":["prompt"]}},
+    \\{"name":"run_swarm","description":"Spawn a self-organizing swarm of parallel Codex sub-agents to tackle a task. An orchestrator agent decomposes the task into sub-tasks, up to max_agents run concurrently via Zig threads, and a synthesis agent combines their outputs. Set writable=true to allow agents to edit files (for bug fixes, refactors). Best for broad research, multi-file analysis, multi-angle reviews, or parallel bug fixing.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"The high-level task for the swarm to solve"},"max_agents":{"type":"integer","description":"Maximum parallel sub-agents (default 5, hard cap 100)"},"writable":{"type":"boolean","description":"Allow agents to edit files and run shell commands (default false = read-only analysis)"},"telemetry_out":{"type":"string","description":"Optional file path to write telemetry JSON (cost, tokens, wall time, parallelism)"}},"required":["prompt"]}},
     \\{"name":"review_fix_loop","description":"Iterative review-fix-review loop. Runs a read-only reviewer to find issues, then a writable agent to fix them, then re-reviews. Repeats until the reviewer reports no remaining issues or max_iterations is reached. Returns a JSON object with iteration history and convergence status.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"Override the default review criteria"},"max_iterations":{"type":"integer","description":"Maximum review-fix cycles (default 3, max 5)"}},"required":[]}},
     \\{"name":"run_agent","description":"Run a single agent turn. Provider-agnostic: resolves the best backend (Claude/Codex) based on mode, role, and available providers. The primitive layer — use run_task for smart multi-step execution.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"The task or question for the agent"},"model":{"type":"string","description":"Model alias or full ID (default: claude-sonnet-4-6). Use \"opus\" for hardest tasks, \"haiku\" for fast/cheap."},"role":{"type":"string","description":"Agent role: finder, reviewer, fixer, explorer, architect, orchestrator, synthesizer, monitor"},"mode":{"type":"string","enum":["smart","rush","deep","free"],"description":"Agent mode: smart (Sonnet), rush (Haiku), deep (Opus), free (Haiku)"},"allowed_tools":{"type":"string","description":"Comma-separated tool allowlist, e.g. \"Bash,Read,Edit\". Omit to allow all tools."},"permission_mode":{"type":"string","enum":["default","acceptEdits","bypassPermissions"],"description":"Permission mode for file and shell operations"},"writable":{"type":"boolean","description":"Allow file writes (maps to bypassPermissions when permission_mode is unset)"},"cwd":{"type":"string","description":"Working directory override (default: current repo path)"}},"required":["prompt"]}},
     \\{"name":"run_task","description":"Smart executor: analyzes a task, picks the right strategy and agents, runs them with appropriate roles and models. Use this instead of run_agent for multi-step tasks. Supports chain presets (finder_fixer, reviewer_fixer, explore_report, architect_build) or auto-selection.","inputSchema":{"type":"object","properties":{"task":{"type":"string","description":"Task description — what needs to be done"},"preset":{"type":"string","enum":["finder_fixer","reviewer_fixer","explore_report","architect_build","custom"],"description":"Chain preset (default: auto-select based on task)"},"mode":{"type":"string","enum":["smart","rush","deep","free"],"description":"Agent mode for all agents in the chain"},"max_agents":{"type":"integer","description":"Max agents to spawn (default: preset-determined)"},"writable":{"type":"boolean","description":"Override write access (default: role-determined)"},"permission_mode":{"type":"string","enum":["default","acceptEdits","bypassPermissions"],"description":"Permission mode for file and shell operations"}},"required":["task"]}}
@@ -242,58 +242,56 @@ pub fn dispatch(
 ) void {
     switch (tool) {
         // Planning
-        .decompose_feature     => handleDecomposeFeature(alloc, args, out),
-        .get_project_state     => handleGetProjectState(alloc, args, out),
-        .get_next_task         => handleGetNextTask(alloc, args, out),
-        .prioritize_issues     => handlePrioritizeIssues(alloc, args, out),
+        .decompose_feature => handleDecomposeFeature(alloc, args, out),
+        .get_project_state => handleGetProjectState(alloc, args, out),
+        .get_next_task => handleGetNextTask(alloc, args, out),
+        .prioritize_issues => handlePrioritizeIssues(alloc, args, out),
         // Issues
-        .create_issue          => handleCreateIssue(alloc, args, out),
-        .create_issues_batch   => handleCreateIssuesBatch(alloc, args, out),
-        .update_issue          => handleUpdateIssue(alloc, args, out),
-        .close_issues_batch    => handleCloseIssuesBatch(alloc, args, out),
-        .close_issue           => handleCloseIssue(alloc, args, out),
-        .link_issues           => handleLinkIssues(alloc, args, out),
-        .get_issue             => handleGetIssue(alloc, args, out),
+        .create_issue => handleCreateIssue(alloc, args, out),
+        .create_issues_batch => handleCreateIssuesBatch(alloc, args, out),
+        .update_issue => handleUpdateIssue(alloc, args, out),
+        .close_issues_batch => handleCloseIssuesBatch(alloc, args, out),
+        .close_issue => handleCloseIssue(alloc, args, out),
+        .link_issues => handleLinkIssues(alloc, args, out),
+        .get_issue => handleGetIssue(alloc, args, out),
         // Branches & commits
-        .create_branch         => handleCreateBranch(alloc, args, out),
-        .get_current_branch    => handleGetCurrentBranch(alloc, args, out),
-        .commit_with_context   => handleCommitWithContext(alloc, args, out),
-        .push_branch           => handlePushBranch(alloc, args, out),
+        .create_branch => handleCreateBranch(alloc, args, out),
+        .get_current_branch => handleGetCurrentBranch(alloc, args, out),
+        .commit_with_context => handleCommitWithContext(alloc, args, out),
+        .push_branch => handlePushBranch(alloc, args, out),
         // Pull requests
-        .create_pr             => handleCreatePr(alloc, args, out),
-        .get_pr_status         => handleGetPrStatus(alloc, args, out),
-        .list_open_prs         => handleListOpenPrs(alloc, args, out),
-        .merge_pr              => handleMergePr(alloc, args, out),
-        .get_pr_diff           => handleGetPrDiff(alloc, args, out),
+        .create_pr => handleCreatePr(alloc, args, out),
+        .get_pr_status => handleGetPrStatus(alloc, args, out),
+        .list_open_prs => handleListOpenPrs(alloc, args, out),
+        .merge_pr => handleMergePr(alloc, args, out),
+        .get_pr_diff => handleGetPrDiff(alloc, args, out),
         // Analysis
-        .review_pr_impact      => handleReviewPrImpact(alloc, args, out),
-        .blast_radius          => handleBlastRadius(alloc, args, out),
-        .relevant_context      => handleRelevantContext(alloc, args, out),
-        .git_history_for       => handleGitHistoryFor(alloc, args, out),
-        .recently_changed      => handleRecentlyChanged(alloc, args, out),
+        .review_pr_impact => handleReviewPrImpact(alloc, args, out),
+        .blast_radius => handleBlastRadius(alloc, args, out),
+        .relevant_context => handleRelevantContext(alloc, args, out),
+        .git_history_for => handleGitHistoryFor(alloc, args, out),
+        .recently_changed => handleRecentlyChanged(alloc, args, out),
         // Graph queries
-        .symbol_at             => handleSymbolAt(alloc, args, out),
-        .find_callers          => handleFindCallers(alloc, args, out),
-        .find_callees          => handleFindCallees(alloc, args, out),
-        .find_dependents       => handleFindDependents(alloc, args, out),
+        .symbol_at => handleSymbolAt(alloc, args, out),
+        .find_callers => handleFindCallers(alloc, args, out),
+        .find_callees => handleFindCallees(alloc, args, out),
+        .find_dependents => handleFindDependents(alloc, args, out),
         // Repository management
-        .set_repo              => handleSetRepo(alloc, args, out),
+        .set_repo => handleSetRepo(alloc, args, out),
         // Agents
-        .run_reviewer          => handleRunReviewer(alloc, args, out),
-        .run_explorer          => handleRunExplorer(alloc, args, out),
-        .run_zig_infra         => handleRunZigInfra(alloc, args, out),
+        .run_reviewer => handleRunReviewer(alloc, args, out),
+        .run_explorer => handleRunExplorer(alloc, args, out),
+        .run_zig_infra => handleRunZigInfra(alloc, args, out),
         // Swarm
-        .run_swarm             => handleRunSwarm(alloc, args, out),
+        .run_swarm => handleRunSwarm(alloc, args, out),
         // Iterative review-fix loop
-        .review_fix_loop       => handleReviewFixLoop(alloc, args, out),
+        .review_fix_loop => handleReviewFixLoop(alloc, args, out),
         // Claude Agent SDK
-        .run_agent             => handleRunAgent(alloc, args, out),
+        .run_agent => handleRunAgent(alloc, args, out),
         // Smart executor
-        .run_task              => handleRunTask(alloc, args, out),
+        .run_task => handleRunTask(alloc, args, out),
     }
 }
-
-
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
 //
@@ -314,10 +312,9 @@ fn handleDecomposeFeature(
         return;
     };
     const labels_r = gh.run(alloc, &.{
-        "gh", "label", "list",
-        "--repo", repo,
-        "--json", "name,description,color",
-        "--limit", "100",
+        "gh",                     "label",   "list",
+        "--repo",                 repo,      "--json",
+        "name,description,color", "--limit", "100",
     }) catch null;
     defer if (labels_r) |r| r.deinit(alloc);
 
@@ -342,10 +339,9 @@ fn handleGetProjectState(
     _ = args;
     const repo = repoOrErr(alloc, out) orelse return;
     const issues_r = gh.run(alloc, &.{
-        "gh", "issue", "list",
-        "--repo", repo,
-        "--json", "number,title,labels,state,url",
-        "--limit", "200",
+        "gh",                            "issue",   "list",
+        "--repo",                        repo,      "--json",
+        "number,title,labels,state,url", "--limit", "200",
     }) catch |err| {
         writeErr(alloc, out, gh.errorMessage(err));
         return;
@@ -353,10 +349,9 @@ fn handleGetProjectState(
     defer issues_r.deinit(alloc);
 
     const prs_r = gh.run(alloc, &.{
-        "gh", "pr", "list",
-        "--repo", repo,
-        "--json", "number,title,state,headRefName,url",
-        "--limit", "50",
+        "gh",                                 "pr",      "list",
+        "--repo",                             repo,      "--json",
+        "number,title,state,headRefName,url", "--limit", "50",
     }) catch |err| {
         writeErr(alloc, out, gh.errorMessage(err));
         return;
@@ -364,13 +359,13 @@ fn handleGetProjectState(
     defer prs_r.deinit(alloc);
 
     const issues_json = std.mem.trim(u8, issues_r.stdout, " \t\n\r");
-    const prs_json    = std.mem.trim(u8, prs_r.stdout,   " \t\n\r");
+    const prs_json = std.mem.trim(u8, prs_r.stdout, " \t\n\r");
 
     out.appendSlice(alloc, "{\"issues\":") catch return;
-    out.appendSlice(alloc, issues_json)     catch return;
+    out.appendSlice(alloc, issues_json) catch return;
     out.appendSlice(alloc, ",\"open_prs\":") catch return;
-    out.appendSlice(alloc, prs_json)        catch return;
-    out.appendSlice(alloc, "}")             catch return;
+    out.appendSlice(alloc, prs_json) catch return;
+    out.appendSlice(alloc, "}") catch return;
 }
 
 fn handleGetNextTask(
@@ -382,11 +377,10 @@ fn handleGetNextTask(
     const repo = repoOrErr(alloc, out) orelse return;
     // Lightweight fetch — just number + labels needed for priority + block filtering
     const parsed = gh.runJson(alloc, &.{
-        "gh", "issue", "list",
-        "--repo", repo,
-        "--label", "status:backlog",
-        "--json", "number,labels",
-        "--limit", "100",
+        "gh",             "issue",  "list",
+        "--repo",         repo,     "--label",
+        "status:backlog", "--json", "number,labels",
+        "--limit",        "100",
     }) catch |err| {
         writeErr(alloc, out, gh.errorMessage(err));
         return;
@@ -408,7 +402,7 @@ fn handleGetNextTask(
 
     // Find highest-priority issue that is not blocked
     var best_num: ?i64 = null;
-    var best_prio: u8  = 255;
+    var best_prio: u8 = 255;
 
     for (items) |item| {
         if (item != .object) continue;
@@ -416,9 +410,12 @@ fn handleGetNextTask(
         if (hasLabel(labels_val, "status:blocked")) continue;
         const prio = getPriority(labels_val);
         const num_val = item.object.get("number") orelse continue;
-        const num = switch (num_val) { .integer => |n| n, else => continue };
+        const num = switch (num_val) {
+            .integer => |n| n,
+            else => continue,
+        };
         if (best_num == null or prio < best_prio) {
-            best_num  = num;
+            best_num = num;
             best_prio = prio;
         }
     }
@@ -432,9 +429,8 @@ fn handleGetNextTask(
     var num_buf: [16]u8 = undefined;
     const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num}) catch return;
     const detail_r = gh.run(alloc, &.{
-        "gh", "issue", "view", num_str,
-        "--repo", repo,
-        "--json", "number,title,body,labels,url,state",
+        "gh",     "issue", "view",   num_str,
+        "--repo", repo,    "--json", "number,title,body,labels,url,state",
     }) catch |err| {
         writeErr(alloc, out, gh.errorMessage(err));
         return;
@@ -450,9 +446,13 @@ fn handlePrioritizeIssues(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const nums_val = args.get("issue_numbers") orelse {
-        writeErr(alloc, out, "missing issue_numbers"); return;
+        writeErr(alloc, out, "missing issue_numbers");
+        return;
     };
-    if (nums_val != .array) { writeErr(alloc, out, "issue_numbers must be array"); return; }
+    if (nums_val != .array) {
+        writeErr(alloc, out, "issue_numbers must be array");
+        return;
+    }
     const nums = nums_val.array.items;
 
     out.appendSlice(alloc, "{\"prioritized\":[") catch return;
@@ -466,14 +466,13 @@ fn handlePrioritizeIssues(
 
         // Strip old priority labels (ignore error — label may not exist)
         const rm = gh.run(alloc, &.{
-            "gh", "issue", "edit", num_str,
-            "--repo", repo,
-            "--remove-label", "priority:p0,priority:p1,priority:p2,priority:p3",
+            "gh",     "issue", "edit",           num_str,
+            "--repo", repo,    "--remove-label", "priority:p0,priority:p1,priority:p2,priority:p3",
         }) catch null;
         if (rm) |r| r.deinit(alloc);
 
         const r = gh.run(alloc, &.{
-            "gh", "issue", "edit", num_str, "--add-label", prio,
+            "gh",     "issue", "edit", num_str, "--add-label", prio,
             "--repo", repo,
         }) catch |err| {
             if (!first) out.appendSlice(alloc, ",") catch {};
@@ -507,7 +506,8 @@ fn handleCreateIssue(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const title = mj.getStr(args, "title") orelse {
-        writeErr(alloc, out, "missing title"); return;
+        writeErr(alloc, out, "missing title");
+        return;
     };
 
     // Build body — optionally append parent issue reference
@@ -556,7 +556,8 @@ fn handleCreateIssue(
     if (mj.getStr(args, "milestone")) |ms| argv.appendSlice(alloc, &.{ "--milestone", ms }) catch return;
 
     const r = gh.run(alloc, argv.items) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
@@ -597,9 +598,13 @@ fn handleCreateIssuesBatch(
     out: *std.ArrayList(u8),
 ) void {
     const issues_val = args.get("issues") orelse {
-        writeErr(alloc, out, "missing issues array"); return;
+        writeErr(alloc, out, "missing issues array");
+        return;
     };
-    if (issues_val != .array) { writeErr(alloc, out, "issues must be array"); return; }
+    if (issues_val != .array) {
+        writeErr(alloc, out, "issues must be array");
+        return;
+    }
 
     out.appendSlice(alloc, "[") catch return;
     var first = true;
@@ -625,9 +630,13 @@ fn handleUpdateIssue(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const num_val = args.get("issue_number") orelse {
-        writeErr(alloc, out, "missing issue_number"); return;
+        writeErr(alloc, out, "missing issue_number");
+        return;
     };
-    if (num_val != .integer) { writeErr(alloc, out, "issue_number must be integer"); return; }
+    if (num_val != .integer) {
+        writeErr(alloc, out, "issue_number must be integer");
+        return;
+    }
     var num_buf: [16]u8 = undefined;
     const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num_val.integer}) catch return;
 
@@ -636,7 +645,7 @@ fn handleUpdateIssue(
     argv.appendSlice(alloc, &.{ "gh", "issue", "edit", num_str, "--repo", repo }) catch return;
 
     if (mj.getStr(args, "title")) |t| argv.appendSlice(alloc, &.{ "--title", t }) catch return;
-    if (mj.getStr(args, "body"))  |b| argv.appendSlice(alloc, &.{ "--body",  b }) catch return;
+    if (mj.getStr(args, "body")) |b| argv.appendSlice(alloc, &.{ "--body", b }) catch return;
 
     if (args.get("add_labels")) |lv| {
         if (lv == .array) {
@@ -654,11 +663,13 @@ fn handleUpdateIssue(
     }
 
     if (argv.items.len == 6) { // only "gh issue edit N --repo owner/repo" — nothing to do
-        writeErr(alloc, out, "no fields to update"); return;
+        writeErr(alloc, out, "no fields to update");
+        return;
     }
 
     const r = gh.run(alloc, argv.items) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
@@ -667,16 +678,19 @@ fn handleUpdateIssue(
     out.appendSlice(alloc, s) catch {};
 }
 
-
 fn handleCloseIssuesBatch(
     alloc: std.mem.Allocator,
     args: *const std.json.ObjectMap,
     out: *std.ArrayList(u8),
 ) void {
     const numbers_val = args.get("issue_numbers") orelse {
-        writeErr(alloc, out, "missing issue_numbers array"); return;
+        writeErr(alloc, out, "missing issue_numbers array");
+        return;
     };
-    if (numbers_val != .array) { writeErr(alloc, out, "issue_numbers must be array"); return; }
+    if (numbers_val != .array) {
+        writeErr(alloc, out, "issue_numbers must be array");
+        return;
+    }
 
     out.appendSlice(alloc, "[") catch return;
     var first = true;
@@ -708,9 +722,13 @@ fn handleCloseIssue(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const num_val = args.get("issue_number") orelse {
-        writeErr(alloc, out, "missing issue_number"); return;
+        writeErr(alloc, out, "missing issue_number");
+        return;
     };
-    if (num_val != .integer) { writeErr(alloc, out, "issue_number must be integer"); return; }
+    if (num_val != .integer) {
+        writeErr(alloc, out, "issue_number must be integer");
+        return;
+    }
     var num_buf: [16]u8 = undefined;
     const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num_val.integer}) catch return;
 
@@ -725,16 +743,16 @@ fn handleCloseIssue(
     }
 
     const close_r = gh.run(alloc, &.{ "gh", "issue", "close", num_str, "--repo", repo }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     close_r.deinit(alloc);
 
     // Transition label: remove all status labels, apply status:done
     const edit_r = gh.run(alloc, &.{
-        "gh", "issue", "edit", num_str,
-        "--repo", repo,
-        "--remove-label", "status:backlog,status:in-progress,status:in-review,status:blocked",
-        "--add-label",    "status:done",
+        "gh",          "issue",       "edit",           num_str,
+        "--repo",      repo,          "--remove-label", "status:backlog,status:in-progress,status:in-review,status:blocked",
+        "--add-label", "status:done",
     }) catch null;
     if (edit_r) |r| r.deinit(alloc);
 
@@ -750,17 +768,28 @@ fn handleLinkIssues(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const blocker_val = args.get("issue_number") orelse {
-        writeErr(alloc, out, "missing issue_number"); return;
+        writeErr(alloc, out, "missing issue_number");
+        return;
     };
-    if (blocker_val != .integer) { writeErr(alloc, out, "issue_number must be integer"); return; }
+    if (blocker_val != .integer) {
+        writeErr(alloc, out, "issue_number must be integer");
+        return;
+    }
     const blocker = blocker_val.integer;
 
     const blocks_val = args.get("blocks") orelse {
-        writeErr(alloc, out, "missing blocks array"); return;
+        writeErr(alloc, out, "missing blocks array");
+        return;
     };
-    if (blocks_val != .array) { writeErr(alloc, out, "blocks must be array"); return; }
+    if (blocks_val != .array) {
+        writeErr(alloc, out, "blocks must be array");
+        return;
+    }
     const blocked_items = blocks_val.array.items;
-    if (blocked_items.len == 0) { out.appendSlice(alloc, "{\"linked\":[]}") catch {}; return; }
+    if (blocked_items.len == 0) {
+        out.appendSlice(alloc, "{\"linked\":[]}") catch {};
+        return;
+    }
 
     // Build comma list "Blocks #X, #Y, #Z" for blocker comment
     var comment: std.ArrayList(u8) = .empty;
@@ -820,26 +849,30 @@ fn handleGetIssue(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const num_val = args.get("issue_number") orelse {
-        writeErr(alloc, out, "missing issue_number"); return;
+        writeErr(alloc, out, "missing issue_number");
+        return;
     };
-    if (num_val != .integer) { writeErr(alloc, out, "issue_number must be integer"); return; }
+    if (num_val != .integer) {
+        writeErr(alloc, out, "issue_number must be integer");
+        return;
+    }
     var num_buf: [16]u8 = undefined;
     const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num_val.integer}) catch {
-        writeErr(alloc, out, "issue_number out of range"); return;
+        writeErr(alloc, out, "issue_number out of range");
+        return;
     };
 
     const r = gh.run(alloc, &.{
-        "gh", "issue", "view", num_str,
-        "--repo", repo,
-        "--json", "number,title,body,state,labels,url,comments",
+        "gh",     "issue", "view",   num_str,
+        "--repo", repo,    "--json", "number,title,body,state,labels,url,comments",
     }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
     out.appendSlice(alloc, std.mem.trim(u8, r.stdout, " \t\n\r")) catch {};
 }
-
 
 // ── Branches & commits ────────────────────────────────────────────────────────
 
@@ -850,22 +883,30 @@ fn handleCreateBranch(
 ) void {
     const repo = repoOrErr(alloc, out) orelse return;
     const num_val = args.get("issue_number") orelse {
-        writeErr(alloc, out, "missing issue_number"); return;
+        writeErr(alloc, out, "missing issue_number");
+        return;
     };
-    if (num_val != .integer) { writeErr(alloc, out, "issue_number must be integer"); return; }
+    if (num_val != .integer) {
+        writeErr(alloc, out, "issue_number must be integer");
+        return;
+    }
     const num: u32 = @intCast(num_val.integer);
     var num_buf: [16]u8 = undefined;
     const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num}) catch return;
 
     // Fetch issue title
     const issue_r = gh.run(alloc, &.{
-        "gh", "issue", "view", num_str, "--json", "title",
+        "gh",     "issue", "view", num_str, "--json", "title",
         "--repo", repo,
-    }) catch |err| { writeErr(alloc, out, gh.errorMessage(err)); return; };
+    }) catch |err| {
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
+    };
     defer issue_r.deinit(alloc);
 
     const parsed = std.json.parseFromSlice(std.json.Value, alloc, issue_r.stdout, .{}) catch {
-        writeErr(alloc, out, "could not parse issue JSON"); return;
+        writeErr(alloc, out, "could not parse issue JSON");
+        return;
     };
     defer parsed.deinit();
 
@@ -882,22 +923,23 @@ fn handleCreateBranch(
     const branch_type: state.BranchType = if (std.mem.eql(u8, branch_type_str, "fix")) .fix else .feature;
 
     const branch_name = state.buildBranchName(alloc, branch_type, num, title) catch {
-        writeErr(alloc, out, "could not build branch name"); return;
+        writeErr(alloc, out, "could not build branch name");
+        return;
     };
     defer alloc.free(branch_name);
 
     // Create local branch
     const checkout_r = gh.run(alloc, &.{ "git", "checkout", "-b", branch_name }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     checkout_r.deinit(alloc);
 
     // Transition issue to in-progress
     const edit_r = gh.run(alloc, &.{
-        "gh", "issue", "edit", num_str,
-        "--repo", repo,
-        "--remove-label", "status:backlog,status:blocked",
-        "--add-label",    "status:in-progress",
+        "gh",          "issue",              "edit",           num_str,
+        "--repo",      repo,                 "--remove-label", "status:backlog,status:blocked",
+        "--add-label", "status:in-progress",
     }) catch null;
     if (edit_r) |r| r.deinit(alloc);
 
@@ -942,7 +984,8 @@ fn handleCommitWithContext(
     out: *std.ArrayList(u8),
 ) void {
     const message = mj.getStr(args, "message") orelse {
-        writeErr(alloc, out, "missing message"); return;
+        writeErr(alloc, out, "missing message");
+        return;
     };
 
     // Resolve issue number: explicit arg > parsed from branch name
@@ -977,24 +1020,28 @@ fn handleCommitWithContext(
                 }
             }
             const add_r = gh.run(alloc, add_argv.items) catch |err| {
-                writeErr(alloc, out, gh.errorMessage(err)); return;
+                writeErr(alloc, out, gh.errorMessage(err));
+                return;
             };
             add_r.deinit(alloc);
         } else {
             const add_r = gh.run(alloc, &.{ "git", "add", "-A" }) catch |err| {
-                writeErr(alloc, out, gh.errorMessage(err)); return;
+                writeErr(alloc, out, gh.errorMessage(err));
+                return;
             };
             add_r.deinit(alloc);
         }
     } else {
         const add_r = gh.run(alloc, &.{ "git", "add", "-A" }) catch |err| {
-            writeErr(alloc, out, gh.errorMessage(err)); return;
+            writeErr(alloc, out, gh.errorMessage(err));
+            return;
         };
         add_r.deinit(alloc);
     }
 
     const commit_r = gh.run(alloc, &.{ "git", "commit", "-m", full_msg }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer commit_r.deinit(alloc);
 
@@ -1041,7 +1088,8 @@ fn handleCreatePr(
     const repo = repoOrErr(alloc, out) orelse return;
     // Determine current branch + linked issue
     const br_r = gh.run(alloc, &.{ "git", "branch", "--show-current" }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer br_r.deinit(alloc);
     const branch = std.mem.trim(u8, br_r.stdout, " \t\n\r");
@@ -1049,9 +1097,9 @@ fn handleCreatePr(
 
     // Resolve title + body — provided args win, else pull from linked issue
     var title_buf: ?[]u8 = null;
-    var body_buf:  ?[]u8 = null;
+    var body_buf: ?[]u8 = null;
     defer if (title_buf) |b| alloc.free(b);
-    defer if (body_buf)  |b| alloc.free(b);
+    defer if (body_buf) |b| alloc.free(b);
 
     const title: []const u8 = blk: {
         if (mj.getStr(args, "title")) |t| break :blk t;
@@ -1073,8 +1121,7 @@ fn handleCreatePr(
                                     if (bv == .string) {
                                         var bb: [16]u8 = undefined;
                                         const ns2 = std.fmt.bufPrint(&bb, "{d}", .{n}) catch "";
-                                        body_buf = std.fmt.allocPrint(alloc,
-                                            "{s}\n\nCloses #{s}", .{ bv.string, ns2 }) catch null;
+                                        body_buf = std.fmt.allocPrint(alloc, "{s}\n\nCloses #{s}", .{ bv.string, ns2 }) catch null;
                                     }
                                 }
                             }
@@ -1100,13 +1147,15 @@ fn handleCreatePr(
     };
 
     const pr_r = gh.run(alloc, &.{
-        "gh", "pr", "create",
-        "--repo", repo,
-        "--base",  "main",
-        "--head",  branch,
-        "--title", title,
-        "--body",  body,
-    }) catch |err| { writeErr(alloc, out, gh.errorMessage(err)); return; };
+        "gh",      "pr",     "create",
+        "--repo",  repo,     "--base",
+        "main",    "--head", branch,
+        "--title", title,    "--body",
+        body,
+    }) catch |err| {
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
+    };
     defer pr_r.deinit(alloc);
 
     // Parse PR number from URL: https://github.com/.../pull/42
@@ -1120,10 +1169,9 @@ fn handleCreatePr(
         var nb: [16]u8 = undefined;
         const ns = std.fmt.bufPrint(&nb, "{d}", .{n}) catch "";
         const er = gh.run(alloc, &.{
-            "gh", "issue", "edit", ns,
-            "--repo", repo,
-            "--remove-label", "status:in-progress",
-            "--add-label",    "status:in-review",
+            "gh",          "issue",            "edit",           ns,
+            "--repo",      repo,               "--remove-label", "status:in-progress",
+            "--add-label", "status:in-review",
         }) catch null;
         if (er) |r| r.deinit(alloc);
     }
@@ -1151,14 +1199,18 @@ fn handleGetPrStatus(
             if (pv == .integer) {
                 var nb: [16]u8 = undefined;
                 const ns = std.fmt.bufPrint(&nb, "{d}", .{pv.integer}) catch {
-                    writeErr(alloc, out, "bad pr_number"); return;
+                    writeErr(alloc, out, "bad pr_number");
+                    return;
                 };
                 break :blk gh.run(alloc, &.{ "gh", "pr", "view", ns, "--repo", repo, "--json", fields });
             }
         }
         // Default: PR for current branch
         break :blk gh.run(alloc, &.{ "gh", "pr", "view", "--repo", repo, "--json", fields });
-    } catch |err| { writeErr(alloc, out, gh.errorMessage(err)); return; };
+    } catch |err| {
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
+    };
     defer r.deinit(alloc);
     out.appendSlice(alloc, std.mem.trim(u8, r.stdout, " \t\n\r")) catch {};
 }
@@ -1171,11 +1223,13 @@ fn handleListOpenPrs(
     _ = args;
     const repo = repoOrErr(alloc, out) orelse return;
     const r = gh.run(alloc, &.{
-        "gh", "pr", "list",
-        "--repo", repo,
-        "--json", "number,title,state,headRefName,url,statusCheckRollup",
-        "--limit", "50",
-    }) catch |err| { writeErr(alloc, out, gh.errorMessage(err)); return; };
+        "gh",                                                   "pr",      "list",
+        "--repo",                                               repo,      "--json",
+        "number,title,state,headRefName,url,statusCheckRollup", "--limit", "50",
+    }) catch |err| {
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
+    };
     defer r.deinit(alloc);
     out.appendSlice(alloc, std.mem.trim(u8, r.stdout, " \t\n\r")) catch {};
 }
@@ -1195,7 +1249,8 @@ fn handleMergePr(
         if (pv == .integer) {
             var nb: [16]u8 = undefined;
             const ns = std.fmt.bufPrint(&nb, "{d}", .{pv.integer}) catch {
-                writeErr(alloc, out, "bad pr_number"); return;
+                writeErr(alloc, out, "bad pr_number");
+                return;
             };
             argv.appendSlice(alloc, &.{ns}) catch return;
         }
@@ -1221,7 +1276,8 @@ fn handleMergePr(
     }
 
     const r = gh.run(alloc, argv.items) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
@@ -1241,13 +1297,17 @@ fn handleGetPrDiff(
             if (pv == .integer) {
                 var nb: [16]u8 = undefined;
                 const ns = std.fmt.bufPrint(&nb, "{d}", .{pv.integer}) catch {
-                    writeErr(alloc, out, "bad pr_number"); return;
+                    writeErr(alloc, out, "bad pr_number");
+                    return;
                 };
                 break :blk gh.run(alloc, &.{ "gh", "pr", "diff", ns, "--repo", repo });
             }
         }
         break :blk gh.run(alloc, &.{ "gh", "pr", "diff", "--repo", repo });
-    } catch |err| { writeErr(alloc, out, gh.errorMessage(err)); return; };
+    } catch |err| {
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
+    };
     defer r.deinit(alloc);
     out.appendSlice(alloc, "{\"diff\":\"") catch return;
     mj.writeEscaped(alloc, out, std.mem.trim(u8, r.stdout, " \t\n\r"));
@@ -1267,13 +1327,17 @@ fn handleReviewPrImpact(
             if (pv == .integer) {
                 var nb: [16]u8 = undefined;
                 const ns = std.fmt.bufPrint(&nb, "{d}", .{pv.integer}) catch {
-                    writeErr(alloc, out, "bad pr_number"); return;
+                    writeErr(alloc, out, "bad pr_number");
+                    return;
                 };
                 break :blk gh.run(alloc, &.{ "gh", "pr", "diff", ns });
             }
         }
         break :blk gh.run(alloc, &.{ "gh", "pr", "diff" });
-    } catch |err| { writeErr(alloc, out, gh.errorMessage(err)); return; };
+    } catch |err| {
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
+    };
     defer diff_r.deinit(alloc);
 
     const diff = std.mem.trim(u8, diff_r.stdout, " \t\n\r");
@@ -1299,7 +1363,10 @@ fn handleReviewPrImpact(
             if (search.extractFilePath(line)) |path| {
                 if (!seen_files.contains(path)) {
                     const owned = alloc.dupe(u8, path) catch continue;
-                    files.append(alloc, owned) catch { alloc.free(owned); continue; };
+                    files.append(alloc, owned) catch {
+                        alloc.free(owned);
+                        continue;
+                    };
                     seen_files.put(owned, {}) catch {};
                     current_file = owned;
                 } else {
@@ -1317,7 +1384,8 @@ fn handleReviewPrImpact(
                 if (!seen_syms.contains(sym)) {
                     const owned_sym = alloc.dupe(u8, sym) catch continue;
                     symbols.append(alloc, .{ .name = owned_sym, .file = current_file }) catch {
-                        alloc.free(owned_sym); continue;
+                        alloc.free(owned_sym);
+                        continue;
                     };
                     seen_syms.put(owned_sym, {}) catch {};
                     sym_count += 1;
@@ -1332,7 +1400,8 @@ fn handleReviewPrImpact(
                 if (!seen_syms.contains(sym)) {
                     const owned_sym = alloc.dupe(u8, sym) catch continue;
                     symbols.append(alloc, .{ .name = owned_sym, .file = current_file }) catch {
-                        alloc.free(owned_sym); continue;
+                        alloc.free(owned_sym);
+                        continue;
                     };
                     seen_syms.put(owned_sym, {}) catch {};
                     sym_count += 1;
@@ -1416,13 +1485,21 @@ fn handleBlastRadius(
     }
 
     if (sym_arg) |s| {
-        const owned = alloc.dupe(u8, s) catch { writeErr(alloc, out, "alloc failed"); return; };
-        syms.append(alloc, owned) catch { alloc.free(owned); writeErr(alloc, out, "alloc failed"); return; };
+        const owned = alloc.dupe(u8, s) catch {
+            writeErr(alloc, out, "alloc failed");
+            return;
+        };
+        syms.append(alloc, owned) catch {
+            alloc.free(owned);
+            writeErr(alloc, out, "alloc failed");
+            return;
+        };
     }
 
     if (file_arg) |f| {
         const r = gh.run(alloc, &.{ "cat", f }) catch |err| {
-            writeErr(alloc, out, gh.errorMessage(err)); return;
+            writeErr(alloc, out, gh.errorMessage(err));
+            return;
         };
         defer r.deinit(alloc);
 
@@ -1431,7 +1508,10 @@ fn handleBlastRadius(
         for (extracted.items) |s| {
             // Dupe: extracted slices point into r.stdout which is freed by defer above
             const owned = alloc.dupe(u8, s) catch continue;
-            syms.append(alloc, owned) catch { alloc.free(owned); continue; };
+            syms.append(alloc, owned) catch {
+                alloc.free(owned);
+                continue;
+            };
         }
     }
 
@@ -1482,11 +1562,13 @@ fn handleRelevantContext(
     out: *std.ArrayList(u8),
 ) void {
     const file_arg = mj.getStr(args, "file") orelse {
-        writeErr(alloc, out, "missing file"); return;
+        writeErr(alloc, out, "missing file");
+        return;
     };
 
     const r = gh.run(alloc, &.{ "cat", file_arg }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
@@ -1521,7 +1603,10 @@ fn handleRelevantContext(
                 if (scores.getPtr(ref)) |vp| vp.* += 1;
             } else {
                 const owned = alloc.dupe(u8, ref) catch continue;
-                scores.put(owned, 1) catch { alloc.free(owned); continue; };
+                scores.put(owned, 1) catch {
+                    alloc.free(owned);
+                    continue;
+                };
             }
         }
     }
@@ -1541,7 +1626,10 @@ fn handleRelevantContext(
                         if (scores.getPtr(full)) |vp| vp.* += 10;
                     } else {
                         const owned = alloc.dupe(u8, full) catch continue;
-                        scores.put(owned, 10) catch { alloc.free(owned); continue; };
+                        scores.put(owned, 10) catch {
+                            alloc.free(owned);
+                            continue;
+                        };
                     }
                 }
             }
@@ -1594,7 +1682,8 @@ fn handleGitHistoryFor(
     out: *std.ArrayList(u8),
 ) void {
     const file_arg = mj.getStr(args, "file") orelse {
-        writeErr(alloc, out, "missing file"); return;
+        writeErr(alloc, out, "missing file");
+        return;
     };
 
     var count_buf: [8]u8 = undefined;
@@ -1608,10 +1697,11 @@ fn handleGitHistoryFor(
     };
 
     const r = gh.run(alloc, &.{
-        "git", "log", "--follow", "--format=%h%x00%an%x00%ai%x00%s",
-        "-n", count_str, "--", file_arg,
+        "git", "log",     "--follow", "--format=%h%x00%an%x00%ai%x00%s",
+        "-n",  count_str, "--",       file_arg,
     }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
@@ -1670,7 +1760,8 @@ fn handleRecentlyChanged(
     const r = gh.run(alloc, &.{
         "git", "log", "--name-only", "--pretty=format:", "-n", count_str,
     }) catch |err| {
-        writeErr(alloc, out, gh.errorMessage(err)); return;
+        writeErr(alloc, out, gh.errorMessage(err));
+        return;
     };
     defer r.deinit(alloc);
 
@@ -1956,7 +2047,6 @@ fn writeErr(alloc: std.mem.Allocator, out: *std.ArrayList(u8), msg: []const u8) 
 
 // ── Repository management ─────────────────────────────────────────────────────
 
-
 // ── Agent runners ─────────────────────────────────────────────────────────────
 //
 // Each handler shells out to `codex exec` with the appropriate prompt.
@@ -1964,12 +2054,12 @@ fn writeErr(alloc: std.mem.Allocator, out: *std.ArrayList(u8), msg: []const u8) 
 // servers (including gitagent-mcp itself), keeping the subprocess fast.
 
 fn runAgentWithRole(
-    alloc:  std.mem.Allocator,
-    role:   []const u8,
-    mode:   ?[]const u8,
+    alloc: std.mem.Allocator,
+    role: []const u8,
+    mode: ?[]const u8,
     writable_flag: ?bool,
     prompt: []const u8,
-    out:    *std.ArrayList(u8),
+    out: *std.ArrayList(u8),
 ) void {
     runChainStep(alloc, role, mode, writable_flag, null, prompt, out);
 }
@@ -1981,10 +2071,10 @@ fn handleRunReviewer(
 ) void {
     const prompt = mj.getStr(args, "prompt") orelse
         "Review the current branch for correctness and memory safety. " ++
-        "Check: errdefer on every allocation, RwLock ordering, " ++
-        "Zig 0.15.x API (ArrayList.empty, append(alloc,v), deinit(alloc)), " ++
-        "PPR push rule correctness, and missing test coverage. " ++
-        "Lead with concrete findings, include file:line references.";
+            "Check: errdefer on every allocation, RwLock ordering, " ++
+            "Zig 0.15.x API (ArrayList.empty, append(alloc,v), deinit(alloc)), " ++
+            "PPR push rule correctness, and missing test coverage. " ++
+            "Lead with concrete findings, include file:line references.";
     runAgentWithRole(alloc, "reviewer", null, false, prompt, out);
 }
 
@@ -2007,9 +2097,9 @@ fn handleRunZigInfra(
 ) void {
     const prompt = mj.getStr(args, "prompt") orelse
         "Review build.zig: check every module uses @import(\"name\") not relative paths, " ++
-        "every module with tests is wired into test_step, no circular deps exist in " ++
-        "types->graph->ppr / types->edge_weights / graph+types->ingest->registry. " ++
-        "Flag any @import(\"../path\") that crosses module boundaries.";
+            "every module with tests is wired into test_step, no circular deps exist in " ++
+            "types->graph->ppr / types->edge_weights / graph+types->ingest->registry. " ++
+            "Flag any @import(\"../path\") that crosses module boundaries.";
     runAgentWithRole(alloc, "fixer", "smart", true, prompt, out);
 }
 
@@ -2063,7 +2153,8 @@ fn handleRunSwarm(alloc: std.mem.Allocator, args: *const std.json.ObjectMap, out
         }
         break :blk false;
     };
-    swarm.runSwarm(alloc, prompt, max_agents, out, writable);
+    const telemetry_out: ?[]const u8 = mj.getStr(args, "telemetry_out");
+    swarm.runSwarm(alloc, prompt, max_agents, out, writable, telemetry_out);
 }
 
 fn handleReviewFixLoop(
@@ -2132,13 +2223,14 @@ fn handleReviewFixLoop(
         }
 
         // ── Phase 2: Fix (writable) via runtime pipeline ─────────────────
-        const fix_prompt = std.fmt.allocPrint(alloc,
+        const fix_prompt = std.fmt.allocPrint(
+            alloc,
             "You are a code fixer. The following review findings were reported. " ++
-            "Fix ALL issues listed below. Use zigread to read files, zigpatch to edit, " ++
-            "and zigdiff to verify each fix. Do not introduce new functionality — " ++
-            "only fix the reported issues.\n\n" ++
-            "REVIEW FINDINGS:\n{s}",
-            .{ review_text },
+                "Fix ALL issues listed below. Use zigread to read files, zigpatch to edit, " ++
+                "and zigdiff to verify each fix. Do not introduce new functionality — " ++
+                "only fix the reported issues.\n\n" ++
+                "REVIEW FINDINGS:\n{s}",
+            .{review_text},
         ) catch {
             iter_json.appendSlice(alloc, ",\"fix\":\"OOM: fix prompt\"}") catch return;
             out_json.appendSlice(alloc, iter_json.items) catch return;
@@ -2228,14 +2320,14 @@ fn handleRunAgent(
 
     // Build AgentRequest from MCP params
     const req: rt.AgentRequest = .{
-        .prompt          = final_prompt,
-        .role            = mj.getStr(args, "role"),
-        .mode            = mj.getStr(args, "mode"),
-        .model           = mj.getStr(args, "model"),
-        .allowed_tools   = mj.getStr(args, "allowed_tools"),
+        .prompt = final_prompt,
+        .role = mj.getStr(args, "role"),
+        .mode = mj.getStr(args, "mode"),
+        .model = mj.getStr(args, "model"),
+        .allowed_tools = mj.getStr(args, "allowed_tools"),
         .permission_mode = mj.getStr(args, "permission_mode"),
-        .cwd             = mj.getStr(args, "cwd"),
-        .writable        = blk: {
+        .cwd = mj.getStr(args, "cwd"),
+        .writable = blk: {
             if (args.get("writable")) |v|
                 if (v == .bool) break :blk v.bool;
             break :blk null;
@@ -2259,11 +2351,11 @@ const ChainPreset = enum {
     custom,
 
     fn fromString(s: []const u8) ?ChainPreset {
-        if (std.mem.eql(u8, s, "finder_fixer"))    return .finder_fixer;
-        if (std.mem.eql(u8, s, "reviewer_fixer"))   return .reviewer_fixer;
-        if (std.mem.eql(u8, s, "explore_report"))   return .explore_report;
-        if (std.mem.eql(u8, s, "architect_build"))  return .architect_build;
-        if (std.mem.eql(u8, s, "custom"))           return .custom;
+        if (std.mem.eql(u8, s, "finder_fixer")) return .finder_fixer;
+        if (std.mem.eql(u8, s, "reviewer_fixer")) return .reviewer_fixer;
+        if (std.mem.eql(u8, s, "explore_report")) return .explore_report;
+        if (std.mem.eql(u8, s, "architect_build")) return .architect_build;
+        if (std.mem.eql(u8, s, "custom")) return .custom;
         return null;
     }
 };
@@ -2280,10 +2372,10 @@ fn runChainStep(
 ) void {
     const rt = @import("runtime.zig");
     const req: rt.AgentRequest = .{
-        .prompt          = prompt,
-        .role            = role,
-        .mode            = mode,
-        .writable        = writable_override,
+        .prompt = prompt,
+        .role = role,
+        .mode = mode,
+        .writable = writable_override,
         .permission_mode = permission_mode,
     };
     const resolved = rt.resolve.resolveWithProbe(alloc, req);
@@ -2321,11 +2413,11 @@ fn handleRunTask(
     // Start JSON output
     out.appendSlice(alloc, "{\"preset\":\"") catch return;
     const preset_name: []const u8 = switch (preset) {
-        .finder_fixer    => "finder_fixer",
-        .reviewer_fixer  => "reviewer_fixer",
-        .explore_report  => "explore_report",
+        .finder_fixer => "finder_fixer",
+        .reviewer_fixer => "reviewer_fixer",
+        .explore_report => "explore_report",
         .architect_build => "architect_build",
-        .custom          => "custom",
+        .custom => "custom",
     };
     out.appendSlice(alloc, preset_name) catch return;
     out.appendSlice(alloc, "\",\"steps\":[") catch return;
@@ -2336,9 +2428,11 @@ fn handleRunTask(
             var finder_out: std.ArrayList(u8) = .empty;
             defer finder_out.deinit(alloc);
 
-            const finder_prompt = std.fmt.allocPrint(alloc,
+            const finder_prompt = std.fmt.allocPrint(
+                alloc,
                 "Find all code relevant to the following task. " ++
-                "Report file paths and line numbers.\n\nTASK: {s}", .{task},
+                    "Report file paths and line numbers.\n\nTASK: {s}",
+                .{task},
             ) catch task;
             defer if (finder_prompt.ptr != task.ptr) alloc.free(finder_prompt);
 
@@ -2354,10 +2448,12 @@ fn handleRunTask(
                 // Step 2: fixer (writable) — apply changes based on findings
                 var fixer_out: std.ArrayList(u8) = .empty;
                 defer fixer_out.deinit(alloc);
-                const fixer_prompt = std.fmt.allocPrint(alloc,
+                const fixer_prompt = std.fmt.allocPrint(
+                    alloc,
                     "Fix the following task based on these findings. " ++
-                    "Read files before editing, verify each edit.\n\n" ++
-                    "TASK: {s}\n\nFINDINGS:\n{s}", .{ task, finder_out.items },
+                        "Read files before editing, verify each edit.\n\n" ++
+                        "TASK: {s}\n\nFINDINGS:\n{s}",
+                    .{ task, finder_out.items },
                 ) catch task;
                 defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
 
@@ -2387,8 +2483,10 @@ fn handleRunTask(
                 var fixer_out: std.ArrayList(u8) = .empty;
                 defer fixer_out.deinit(alloc);
 
-                const fixer_prompt = std.fmt.allocPrint(alloc,
-                    "Fix ALL issues listed below.\n\nREVIEW FINDINGS:\n{s}", .{review_out.items},
+                const fixer_prompt = std.fmt.allocPrint(
+                    alloc,
+                    "Fix ALL issues listed below.\n\nREVIEW FINDINGS:\n{s}",
+                    .{review_out.items},
                 ) catch task;
                 defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
 
@@ -2416,9 +2514,11 @@ fn handleRunTask(
                 // Step 2: synthesizer (read-only) — summarize findings
                 var synth_out: std.ArrayList(u8) = .empty;
                 defer synth_out.deinit(alloc);
-                const synth_prompt = std.fmt.allocPrint(alloc,
+                const synth_prompt = std.fmt.allocPrint(
+                    alloc,
                     "Synthesize these exploration findings into a clear report.\n\n" ++
-                    "TASK: {s}\n\nFINDINGS:\n{s}", .{ task, explore_out.items },
+                        "TASK: {s}\n\nFINDINGS:\n{s}",
+                    .{ task, explore_out.items },
                 ) catch task;
                 defer if (synth_prompt.ptr != task.ptr) alloc.free(synth_prompt);
 
@@ -2444,9 +2544,11 @@ fn handleRunTask(
             var fixer_out: std.ArrayList(u8) = .empty;
             defer fixer_out.deinit(alloc);
 
-            const fixer_prompt = std.fmt.allocPrint(alloc,
+            const fixer_prompt = std.fmt.allocPrint(
+                alloc,
                 "Implement the following architectural plan.\n\n" ++
-                "PLAN:\n{s}", .{arch_out.items},
+                    "PLAN:\n{s}",
+                .{arch_out.items},
             ) catch task;
             defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
 

--- a/test_e2e.py
+++ b/test_e2e.py
@@ -1,24 +1,36 @@
 #!/usr/bin/env python3
-"""End-to-end test for all 21 gitagent-mcp tools."""
+"""End-to-end test for all 21 devswarm tools."""
+
 import json, os, subprocess, sys
 from pathlib import Path
 
-_DIR   = Path(__file__).resolve().parent
-BINARY = str(_DIR / "zig-out" / "bin" / "gitagent-mcp")
-REPO   = str(_DIR)
+_DIR = Path(__file__).resolve().parent
+BINARY = str(_DIR / "zig-out" / "bin" / "devswarm")
+REPO = str(_DIR)
+
 
 class MCP:
     def __init__(self):
         env = {**os.environ, "REPO_PATH": REPO}
         self.proc = subprocess.Popen(
-            [BINARY], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL, env=env,
+            [BINARY],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=env,
         )
         self._n = 0
-        self._send({"id": 0, "method": "initialize", "params": {
-            "protocolVersion": "2025-03-26", "capabilities": {},
-            "clientInfo": {"name": "test", "version": "1"},
-        }})
+        self._send(
+            {
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1"},
+                },
+            }
+        )
         self._recv()
 
     def _send(self, obj):
@@ -48,58 +60,91 @@ class MCP:
 
     def _recv(self):
         line = self.proc.stdout.readline()
-        if not line: raise RuntimeError("MCP server closed")
+        if not line:
+            raise RuntimeError("MCP server closed")
         return json.loads(line)
 
     def call(self, tool, **kwargs):
         self._n += 1
-        self._send({"id": self._n, "method": "tools/call",
-                    "params": {"name": tool, "arguments": kwargs}})
+        self._send(
+            {
+                "id": self._n,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": kwargs},
+            }
+        )
         resp = self._recv()
         if "error" in resp:
             return {"error": resp["error"].get("message", str(resp["error"]))}
         text = resp["result"]["content"][0]["text"]
-        try: return json.loads(text)
-        except: return {"error": f"non-JSON: {text[:200]}"}
+        try:
+            return json.loads(text)
+        except:
+            return {"error": f"non-JSON: {text[:200]}"}
 
     def close(self):
-        self.proc.stdin.close(); self.proc.wait(timeout=5)
+        self.proc.stdin.close()
+        self.proc.wait(timeout=5)
 
-PASSED = []; FAILED = []
+
+PASSED = []
+FAILED = []
+
 
 def ok(name, detail=""):
-    print(f"  \033[32mv\033[0m {name}" + (f"  \033[2m{detail}\033[0m" if detail else ""))
+    print(
+        f"  \033[32mv\033[0m {name}" + (f"  \033[2m{detail}\033[0m" if detail else "")
+    )
     PASSED.append(name)
+
 
 def fail(name, reason):
     print(f"  \033[31mx\033[0m {name}  \033[31m{reason}\033[0m")
     FAILED.append(name)
 
+
 def check(name, result, detail="", **expects):
-    if result is None: fail(name, "returned None"); return result
+    if result is None:
+        fail(name, "returned None")
+        return result
     if isinstance(result, dict) and "error" in result:
-        fail(name, result["error"]); return result
+        fail(name, result["error"])
+        return result
     for field, validator in expects.items():
         val = result.get(field) if isinstance(result, dict) else result
         try:
-            if callable(validator): assert validator(val), f"{field}={val!r} failed"
-            else: assert val == validator, f"{field}: expected {validator!r}, got {val!r}"
+            if callable(validator):
+                assert validator(val), f"{field}={val!r} failed"
+            else:
+                assert val == validator, f"{field}: expected {validator!r}, got {val!r}"
         except AssertionError as e:
-            fail(name, str(e)); return result
-    ok(name, detail); return result
+            fail(name, str(e))
+            return result
+    ok(name, detail)
+    return result
+
 
 def run():
     s = MCP()
     alpha = beta = gamma = None
-    branch_name = None; pr_num = None; orig_branch = "main"
+    branch_name = None
+    pr_num = None
+    orig_branch = "main"
 
     try:
         print("\n[1/5] Transport framing recovery")
 
         s._send_raw(b"Content-Length: abc\r\n\r\n{}\r\n")
         r = s._recv()
-        if not isinstance(r, dict) or "error" not in r or r["error"].get("code") != -32700:
-            fail("transport_invalid_framing", f"expected -32700 error frame response, got {r}")
+        if (
+            not isinstance(r, dict)
+            or "error" not in r
+            or r["error"].get("code") != -32700
+        ):
+            fail(
+                "transport_invalid_framing",
+                f"expected -32700 error frame response, got {r}",
+            )
         else:
             ok("transport_invalid_framing", "invalid header rejected")
 
@@ -108,18 +153,24 @@ def run():
         if isinstance(r, dict) and r.get("id") == header_id and "result" in r:
             ok("transport_header_request", f"id={header_id}")
         else:
-            fail("transport_header_request", f"expected result for id {header_id}, got {r}")
+            fail(
+                "transport_header_request",
+                f"expected result for id {header_id}, got {r}",
+            )
 
         print("\n[1/5] Read-only tools")
 
         r = s.call("get_project_state")
-        check("get_project_state", r,
-              detail=f"{len(r.get('issues',[]))} issues, {len(r.get('open_prs',[]))} PRs",
-              issues=lambda x: isinstance(x, list) and len(x) > 0)
+        check(
+            "get_project_state",
+            r,
+            detail=f"{len(r.get('issues', []))} issues, {len(r.get('open_prs', []))} PRs",
+            issues=lambda x: isinstance(x, list) and len(x) > 0,
+        )
 
         r = s.call("get_next_task")
         if r and isinstance(r, dict) and "number" in r:
-            ok("get_next_task", f"#{r['number']} {str(r.get('title',''))[:40]}")
+            ok("get_next_task", f"#{r['number']} {str(r.get('title', ''))[:40]}")
         elif r is None or r == "null":
             ok("get_next_task", "no tasks")
         else:
@@ -127,27 +178,40 @@ def run():
 
         r = s.call("get_current_branch")
         orig_branch = r.get("branch", "main") if isinstance(r, dict) else "main"
-        check("get_current_branch", r, detail=f"{r.get('branch')}",
-              branch=lambda x: isinstance(x, str) and len(x) > 0)
+        check(
+            "get_current_branch",
+            r,
+            detail=f"{r.get('branch')}",
+            branch=lambda x: isinstance(x, str) and len(x) > 0,
+        )
 
         r = s.call("decompose_feature", feature_description="add full-text search")
-        check("decompose_feature", r,
-              detail=f"{len(r.get('available_labels',[]))} labels",
-              available_labels=lambda x: isinstance(x, list) and len(x) > 0,
-              instructions=lambda x: isinstance(x, str))
+        check(
+            "decompose_feature",
+            r,
+            detail=f"{len(r.get('available_labels', []))} labels",
+            available_labels=lambda x: isinstance(x, list) and len(x) > 0,
+            instructions=lambda x: isinstance(x, str),
+        )
 
         # -- Analysis tools (offline, read-only) --
 
         r = s.call("blast_radius", file="src/tools.zig")
-        check("blast_radius (file)", r,
-              detail=f"{len(r.get('symbols',[]))} syms, tool={r.get('search_tool','')}",
-              symbols=lambda x: isinstance(x, list) and len(x) > 0,
-              search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"))
+        check(
+            "blast_radius (file)",
+            r,
+            detail=f"{len(r.get('symbols', []))} syms, tool={r.get('search_tool', '')}",
+            symbols=lambda x: isinstance(x, list) and len(x) > 0,
+            search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"),
+        )
 
         r = s.call("blast_radius", symbol="dispatch")
-        check("blast_radius (symbol)", r,
-              detail=f"{len(r.get('symbols',[]))} syms",
-              symbols=lambda x: isinstance(x, list) and len(x) > 0)
+        check(
+            "blast_radius (symbol)",
+            r,
+            detail=f"{len(r.get('symbols', []))} syms",
+            symbols=lambda x: isinstance(x, list) and len(x) > 0,
+        )
 
         r = s.call("blast_radius")
         if isinstance(r, dict) and "error" in r:
@@ -156,16 +220,26 @@ def run():
             fail("blast_radius (no args)", f"expected error, got {r}")
 
         r = s.call("relevant_context", file="src/tools.zig")
-        check("relevant_context", r,
-              detail=f"{len(r.get('context_files',[]))} files",
-              context_files=lambda x: isinstance(x, list) and len(x) > 0,
-              search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"))
+        check(
+            "relevant_context",
+            r,
+            detail=f"{len(r.get('context_files', []))} files",
+            context_files=lambda x: isinstance(x, list) and len(x) > 0,
+            search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"),
+        )
 
         r = s.call("git_history_for", file="src/tools.zig", count=5)
-        check("git_history_for", r,
-              detail=f"{len(r.get('commits',[]))} commits",
-              commits=lambda x: isinstance(x, list) and len(x) > 0)
-        if isinstance(r, dict) and isinstance(r.get("commits"), list) and len(r["commits"]) > 0:
+        check(
+            "git_history_for",
+            r,
+            detail=f"{len(r.get('commits', []))} commits",
+            commits=lambda x: isinstance(x, list) and len(x) > 0,
+        )
+        if (
+            isinstance(r, dict)
+            and isinstance(r.get("commits"), list)
+            and len(r["commits"]) > 0
+        ):
             c = r["commits"][0]
             if all(k in c for k in ("hash", "author", "date", "message")):
                 ok("git_history_for (schema)", f"hash={c['hash']}")
@@ -173,42 +247,80 @@ def run():
                 fail("git_history_for (schema)", f"missing fields: {list(c.keys())}")
 
         r = s.call("recently_changed", count=5)
-        check("recently_changed", r,
-              detail=f"{len(r.get('files',[]))} files",
-              files=lambda x: isinstance(x, list) and len(x) > 0)
+        check(
+            "recently_changed",
+            r,
+            detail=f"{len(r.get('files', []))} files",
+            files=lambda x: isinstance(x, list) and len(x) > 0,
+        )
 
         print("\n[2/5] Issue management")
 
-        r = s.call("create_issue", title="[TEST] MCP e2e alpha",
-                   body="E2E test.", labels=["type:infra"])
-        r = check("create_issue", r,
-                  detail=f"#{r.get('number')} {r.get('url','')}" if isinstance(r,dict) else "",
-                  number=lambda x: x and x > 0)
-        if r and "number" in r: alpha = r["number"]
+        r = s.call(
+            "create_issue",
+            title="[TEST] MCP e2e alpha",
+            body="E2E test.",
+            labels=["type:infra"],
+        )
+        r = check(
+            "create_issue",
+            r,
+            detail=f"#{r.get('number')} {r.get('url', '')}"
+            if isinstance(r, dict)
+            else "",
+            number=lambda x: x and x > 0,
+        )
+        if r and "number" in r:
+            alpha = r["number"]
 
-        r = s.call("create_issues_batch", issues=[
-            {"title":"[TEST] MCP e2e batch-beta",  "body":"batch 1","labels":["type:infra"]},
-            {"title":"[TEST] MCP e2e batch-gamma","body":"batch 2","labels":["type:infra"]},
-        ])
-        if isinstance(r, list) and len(r)==2 and all(isinstance(i,dict) and i.get("number",0)>0 for i in r):
-            beta=r[0]["number"]; gamma=r[1]["number"]
+        r = s.call(
+            "create_issues_batch",
+            issues=[
+                {
+                    "title": "[TEST] MCP e2e batch-beta",
+                    "body": "batch 1",
+                    "labels": ["type:infra"],
+                },
+                {
+                    "title": "[TEST] MCP e2e batch-gamma",
+                    "body": "batch 2",
+                    "labels": ["type:infra"],
+                },
+            ],
+        )
+        if (
+            isinstance(r, list)
+            and len(r) == 2
+            and all(isinstance(i, dict) and i.get("number", 0) > 0 for i in r)
+        ):
+            beta = r[0]["number"]
+            gamma = r[1]["number"]
             ok("create_issues_batch", f"#{beta}, #{gamma}")
         else:
-            fail("create_issues_batch", f"unexpected: {r}"); beta=gamma=None
+            fail("create_issues_batch", f"unexpected: {r}")
+            beta = gamma = None
 
         if alpha:
-            r = s.call("update_issue", issue_number=alpha,
-                       title="[TEST] MCP e2e alpha (updated)", add_labels=["priority:p2"])
-            check("update_issue", r, detail=f"#{alpha}", updated=lambda x: x==alpha)
+            r = s.call(
+                "update_issue",
+                issue_number=alpha,
+                title="[TEST] MCP e2e alpha (updated)",
+                add_labels=["priority:p2"],
+            )
+            check("update_issue", r, detail=f"#{alpha}", updated=lambda x: x == alpha)
 
         if alpha and beta and gamma:
             r = s.call("prioritize_issues", issue_numbers=[gamma, beta, alpha])
-            check("prioritize_issues", r, detail=str(r.get("prioritized",[])),
-                  prioritized=lambda x: isinstance(x,list) and len(x)==3)
+            check(
+                "prioritize_issues",
+                r,
+                detail=str(r.get("prioritized", [])),
+                prioritized=lambda x: isinstance(x, list) and len(x) == 3,
+            )
 
         if alpha and beta:
             r = s.call("link_issues", issue_number=alpha, blocks=[beta])
-            linked = r.get("linked",[]) if isinstance(r,dict) else []
+            linked = r.get("linked", []) if isinstance(r, dict) else []
             if str(beta) in [str(x) for x in linked] or beta in linked:
                 ok("link_issues", f"#{alpha} blocks #{beta}")
             else:
@@ -216,79 +328,119 @@ def run():
 
         if gamma:
             r = s.call("close_issue", issue_number=gamma)
-            check("close_issue", r, detail=f"#{gamma}", closed=lambda x: x==gamma)
+            check("close_issue", r, detail=f"#{gamma}", closed=lambda x: x == gamma)
 
         print("\n[3/5] Branch & commit workflow")
 
         if alpha:
             r = s.call("create_branch", issue_number=alpha, branch_type="fix")
-            r = check("create_branch", r,
-                      detail=r.get("branch","") if isinstance(r,dict) else "",
-                      branch=lambda x: f"fix/{alpha}-" in (x or ""))
-            if r and "branch" in r: branch_name = r["branch"]
+            r = check(
+                "create_branch",
+                r,
+                detail=r.get("branch", "") if isinstance(r, dict) else "",
+                branch=lambda x: f"fix/{alpha}-" in (x or ""),
+            )
+            if r and "branch" in r:
+                branch_name = r["branch"]
 
         if branch_name:
             r = s.call("get_current_branch")
-            check("get_current_branch (fix branch)", r, detail=r.get("branch",""),
-                  branch=lambda x: x==branch_name, issue_number=lambda x: x==alpha)
+            check(
+                "get_current_branch (fix branch)",
+                r,
+                detail=r.get("branch", ""),
+                branch=lambda x: x == branch_name,
+                issue_number=lambda x: x == alpha,
+            )
 
             Path(f"{REPO}/.mcp-e2e-test").write_text(f"e2e {branch_name}\n")
 
             r = s.call("commit_with_context", message="test: MCP e2e smoke commit")
-            check("commit_with_context", r,
-                  detail=r.get("ref","") if isinstance(r,dict) else "",
-                  committed=lambda x: x==True)
+            check(
+                "commit_with_context",
+                r,
+                detail=r.get("ref", "") if isinstance(r, dict) else "",
+                committed=lambda x: x == True,
+            )
 
             r = s.call("push_branch")
-            check("push_branch", r, detail=r.get("branch","") if isinstance(r,dict) else "",
-                  pushed=lambda x: x==True)
+            check(
+                "push_branch",
+                r,
+                detail=r.get("branch", "") if isinstance(r, dict) else "",
+                pushed=lambda x: x == True,
+            )
 
             r = s.call("list_open_prs")
-            if isinstance(r, list): ok("list_open_prs", f"{len(r)} PRs")
-            else: fail("list_open_prs", f"not a list: {r}")
+            if isinstance(r, list):
+                ok("list_open_prs", f"{len(r)} PRs")
+            else:
+                fail("list_open_prs", f"not a list: {r}")
 
             print("\n[4/5] PR tools")
 
-            r = s.call("create_pr",
-                       title=f"[TEST] MCP e2e PR #{alpha}",
-                       body=f"E2E test PR.\n\nCloses #{alpha}.")
-            r = check("create_pr", r,
-                      detail=f"#{r.get('number')} {r.get('url','')}" if isinstance(r,dict) else str(r),
-                      number=lambda x: x and x > 0)
-            if r and isinstance(r,dict): pr_num = r.get("number")
+            r = s.call(
+                "create_pr",
+                title=f"[TEST] MCP e2e PR #{alpha}",
+                body=f"E2E test PR.\n\nCloses #{alpha}.",
+            )
+            r = check(
+                "create_pr",
+                r,
+                detail=f"#{r.get('number')} {r.get('url', '')}"
+                if isinstance(r, dict)
+                else str(r),
+                number=lambda x: x and x > 0,
+            )
+            if r and isinstance(r, dict):
+                pr_num = r.get("number")
 
             if pr_num:
                 r = s.call("get_pr_status", pr_number=pr_num)
-                check("get_pr_status", r,
-                      detail=f"state={r.get('state')} mergeable={r.get('mergeable')}",
-                      number=lambda x: x==pr_num)
+                check(
+                    "get_pr_status",
+                    r,
+                    detail=f"state={r.get('state')} mergeable={r.get('mergeable')}",
+                    number=lambda x: x == pr_num,
+                )
 
                 r = s.call("list_open_prs")
-                if isinstance(r,list) and any(p.get("number")==pr_num for p in r):
+                if isinstance(r, list) and any(p.get("number") == pr_num for p in r):
                     ok("list_open_prs (with PR)", f"PR #{pr_num} in {len(r)} PRs")
                 else:
                     fail("list_open_prs (with PR)", f"PR #{pr_num} not found")
 
                 # Inline impact test after PR creation
                 r = s.call("review_pr_impact", pr_number=pr_num)
-                check("review_pr_impact", r,
-                      detail=f"{len(r.get('files_changed',[]))} files, {len(r.get('symbols',[]))} syms, tool={r.get('search_tool','')}",
-                      files_changed=lambda x: isinstance(x, list) and len(x) > 0,
-                      search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"))
+                check(
+                    "review_pr_impact",
+                    r,
+                    detail=f"{len(r.get('files_changed', []))} files, {len(r.get('symbols', []))} syms, tool={r.get('search_tool', '')}",
+                    files_changed=lambda x: isinstance(x, list) and len(x) > 0,
+                    search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"),
+                )
 
         print("\n[5/5] PR impact analysis")
 
         if pr_num:
             # Test 1: Valid PR — should return files, symbols, and references
             r_valid = s.call("review_pr_impact", pr_number=pr_num)
-            check("review_pr_impact (valid PR)", r_valid,
-                  files_changed=lambda x: isinstance(x, list) and len(x) > 0,
-                  symbols=lambda x: isinstance(x, list),
-                  search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"))
+            check(
+                "review_pr_impact (valid PR)",
+                r_valid,
+                files_changed=lambda x: isinstance(x, list) and len(x) > 0,
+                symbols=lambda x: isinstance(x, list),
+                search_tool=lambda x: x in ("zigrep", "rg", "grep", "none"),
+            )
 
             # Test 2: Non-existent PR — should return error
             r_bad = s.call("review_pr_impact", pr_number=999999)
-            if isinstance(r_bad, dict) and "error" in r_bad and isinstance(r_bad["error"], str) and len(r_bad["error"]) > 0:
+            if (
+                isinstance(r_bad, dict)
+                and "error" in r_bad
+                and isinstance(r_bad["error"], str)
+                and len(r_bad["error"]) > 0
+            ):
                 ok("review_pr_impact (bad PR)", f"error={r_bad['error'][:40]}")
             else:
                 fail("review_pr_impact (bad PR)", f"expected error, got {r_bad}")
@@ -298,9 +450,13 @@ def run():
                 valid = True
                 for sym in r_valid["symbols"]:
                     if not ("name" in sym and "file" in sym and "referenced_by" in sym):
-                        valid = False; break
+                        valid = False
+                        break
                 if valid:
-                    ok("review_pr_impact (schema)", f"{len(r_valid['symbols'])} symbols validated")
+                    ok(
+                        "review_pr_impact (schema)",
+                        f"{len(r_valid['symbols'])} symbols validated",
+                    )
                 else:
                     fail("review_pr_impact (schema)", "symbol missing required fields")
             else:
@@ -309,30 +465,52 @@ def run():
     finally:
         s.close()
         print("\n-- Cleanup --")
-        subprocess.run(["git","-C",REPO,"checkout",orig_branch], capture_output=True)
+        subprocess.run(
+            ["git", "-C", REPO, "checkout", orig_branch], capture_output=True
+        )
         if pr_num:
-            res = subprocess.run(["gh","pr","close",str(pr_num),"--delete-branch"],
-                                 capture_output=True, text=True, cwd=REPO)
-            print(f"  PR #{pr_num} closed" + ("" if res.returncode==0 else f" (err: {res.stderr.strip()})"))
+            res = subprocess.run(
+                ["gh", "pr", "close", str(pr_num), "--delete-branch"],
+                capture_output=True,
+                text=True,
+                cwd=REPO,
+            )
+            print(
+                f"  PR #{pr_num} closed"
+                + ("" if res.returncode == 0 else f" (err: {res.stderr.strip()})")
+            )
         if branch_name:
-            subprocess.run(["git","-C",REPO,"branch","-D",branch_name], capture_output=True)
+            subprocess.run(
+                ["git", "-C", REPO, "branch", "-D", branch_name], capture_output=True
+            )
             print(f"  local branch {branch_name} deleted")
         for n in [alpha, beta]:
             if n:
-                res = subprocess.run(["gh","issue","close",str(n),"--comment","e2e cleanup"],
-                                     capture_output=True, text=True, cwd=REPO)
-                print(f"  issue #{n} closed" + ("" if res.returncode==0 else " (already closed)"))
+                res = subprocess.run(
+                    ["gh", "issue", "close", str(n), "--comment", "e2e cleanup"],
+                    capture_output=True,
+                    text=True,
+                    cwd=REPO,
+                )
+                print(
+                    f"  issue #{n} closed"
+                    + ("" if res.returncode == 0 else " (already closed)")
+                )
         tf = Path(f"{REPO}/.mcp-e2e-test")
-        if tf.exists(): tf.unlink(); print("  removed .mcp-e2e-test")
+        if tf.exists():
+            tf.unlink()
+            print("  removed .mcp-e2e-test")
 
-    print(f"\n{'='*50}")
-    print(f"Results: {len(PASSED)}/{len(PASSED)+len(FAILED)} passed")
+    print(f"\n{'=' * 50}")
+    print(f"Results: {len(PASSED)}/{len(PASSED) + len(FAILED)} passed")
     if FAILED:
         print("Failed:")
-        for f in FAILED: print(f"  - {f}")
+        for f in FAILED:
+            print(f"  - {f}")
     else:
         print("All 21+ tools passed!")
     return len(FAILED) == 0
+
 
 if __name__ == "__main__":
     sys.exit(0 if run() else 1)


### PR DESCRIPTION
## Problem

`npm/package.json:3` reads:
```json
"version": "0.0.24"
```

But `build.zig.zon:12` and `build.zig:8` are at `0.0.26` (as of the `chore: bump version to 0.0.26` commit).

`npm/install.js:10` uses:
```js
const VERSION = require('./package.json').version;
```

This constructs the GitHub Releases download URL as:
```
https://github.com/justrach/codedb/releases/download/v0.0.24/devswarm-<target>
```

The v0.0.24 release either doesn't exist or doesn't have assets matching the current binary. **Every `npm install devswarm` for new users will fail** with an HTTP error trying to download the binary.

The root cause is likely that `bump-version.yml` ran but the `npm/package.json` sed substitution was not committed correctly.

## Fix

1. Update `npm/package.json` version to `0.0.26` immediately.
2. Investigate why `bump-version.yml` didn't update it (check the workflow run for PR #305).
3. Add a version-consistency check to CI (e.g., compare `build.zig.zon` version with `npm/package.json` version and fail if they differ).

## Acceptance
- `npm/package.json` version matches `build.zig.zon` version
- CI includes a step that fails if the two version strings diverge

Closes #312