### PR TITLE
fix: test_e2e.py references wrong binary name `gitagent-mcp`, should be `devswarm`

### DIFF
--- a/test_e2e.py
+++ b/test_e2e.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""End-to-end test for all 21 gitagent-mcp tools."""
+"""End-to-end test for all 21 devswarm tools."""
 import json, os, subprocess, sys
 from pathlib import Path
 
 _DIR   = Path(__file__).resolve().parent
-BINARY = str(_DIR / "zig-out" / "bin" / "gitagent-mcp")
+BINARY = str(_DIR / "zig-out" / "bin" / "devswarm")
 REPO   = str(_DIR)
 
 class MCP:


### PR DESCRIPTION
Fixes #311