### PR TITLE
fix: correct swarm telemetry metrics and telemetry_out path handling

### DIFF
--- a/src/swarm.zig
+++ b/src/swarm.zig
@@ -80,7 +80,6 @@ fn parseMetricsFromOutput(_: std.mem.Allocator, output: []const u8, metrics: *te
                     const num_str = output[start..i];
                     if (std.fmt.parseInt(u64, num_str, 10)) |val| {
                         metrics.tokens_in = val;
-                        metrics.tokens_out = val / 3;
                     } else |_| {}
                 }
             }
@@ -255,7 +254,7 @@ pub fn runSwarm(
             .string => |s| s,
             else => "agent",
         };
-        worker_metrics[count] = telemetry.WorkerMetrics.init(alloc, @intCast(count), role_str, "claude-sonnet-4-6");
+        worker_metrics[count] = telemetry.WorkerMetrics.init(@intCast(count), role_str, "claude-sonnet-4-6");
         workers[count] = .{
             .id = @intCast(count),
             .role = role_str,
@@ -370,11 +369,18 @@ pub fn runSwarm(
         std.debug.print("\n[telemetry] {s}\n", .{telemetry_json});
 
         if (telemetry_out) |path| {
-            const file = std.fs.createFileAbsolute(path, .{}) catch |err| {
-                std.debug.print("[telemetry] failed to write to {s}: {}\n", .{ path, err });
-                alloc.free(telemetry_json);
-                return;
-            };
+            const file = if (std.fs.path.isAbsolute(path))
+                std.fs.createFileAbsolute(path, .{}) catch |err| {
+                    std.debug.print("[telemetry] failed to write to {s}: {}\n", .{ path, err });
+                    alloc.free(telemetry_json);
+                    return;
+                }
+            else
+                std.fs.cwd().createFile(path, .{}) catch |err| {
+                    std.debug.print("[telemetry] failed to write to {s}: {}\n", .{ path, err });
+                    alloc.free(telemetry_json);
+                    return;
+                };
             defer file.close();
             file.writeAll(telemetry_json) catch {};
             file.writeAll("\n") catch {};

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -10,35 +10,18 @@ pub const WorkerMetrics = struct {
     tokens_out: u64 = 0,
     wall_ms: u64 = 0,
     errors: u32 = 0,
-    files_read: std.ArrayList([]const u8),
-    files_written: std.ArrayList([]const u8),
 
-    pub fn init(alloc: std.mem.Allocator, id: u32, role: []const u8, model: []const u8) WorkerMetrics {
-        _ = alloc;
+    pub fn init(id: u32, role: []const u8, model: []const u8) WorkerMetrics {
         return .{
             .worker_id = id,
             .role = role,
             .model = model,
-            .files_read = .empty,
-            .files_written = .empty,
         };
     }
 
     pub fn deinit(self: *WorkerMetrics, alloc: std.mem.Allocator) void {
-        for (self.files_read.items) |f| alloc.free(f);
-        for (self.files_written.items) |f| alloc.free(f);
-        self.files_read.deinit(alloc);
-        self.files_written.deinit(alloc);
-    }
-
-    pub fn addFileRead(self: *WorkerMetrics, alloc: std.mem.Allocator, path: []const u8) void {
-        const owned = alloc.dupe(u8, path) catch return;
-        self.files_read.append(alloc, owned) catch alloc.free(owned);
-    }
-
-    pub fn addFileWritten(self: *WorkerMetrics, alloc: std.mem.Allocator, path: []const u8) void {
-        const owned = alloc.dupe(u8, path) catch return;
-        self.files_written.append(alloc, owned) catch alloc.free(owned);
+        _ = self;
+        _ = alloc;
     }
 };
 
@@ -302,21 +285,7 @@ pub const SwarmTelemetry = struct {
         const err_str = std.fmt.bufPrint(&tmp, "{d}", .{w.errors}) catch "";
         buf.appendSlice(alloc, err_str) catch return;
 
-        buf.appendSlice(alloc, ",\"files_read\":[") catch return;
-        for (w.files_read.items, 0..) |f, i| {
-            if (i > 0) buf.appendSlice(alloc, ",") catch return;
-            buf.append(alloc, '"') catch return;
-            mj.writeEscaped(alloc, buf, f);
-            buf.append(alloc, '"') catch return;
-        }
-        buf.appendSlice(alloc, "],\"files_written\":[") catch return;
-        for (w.files_written.items, 0..) |f, i| {
-            if (i > 0) buf.appendSlice(alloc, ",") catch return;
-            buf.append(alloc, '"') catch return;
-            mj.writeEscaped(alloc, buf, f);
-            buf.append(alloc, '"') catch return;
-        }
-        buf.appendSlice(alloc, "]}") catch return;
+        buf.appendSlice(alloc, "}") catch return;
     }
 };
 
@@ -344,25 +313,12 @@ fn estimateCost(model: []const u8, tokens_in: u64, tokens_out: u64) f64 {
 
 test "telemetry: WorkerMetrics init and deinit" {
     const alloc = std.testing.allocator;
-    var w = WorkerMetrics.init(alloc, 0, "finder", "claude-sonnet-4-6");
+    var w = WorkerMetrics.init(0, "finder", "claude-sonnet-4-6");
     defer w.deinit(alloc);
 
     try std.testing.expectEqual(@as(u32, 0), w.worker_id);
     try std.testing.expectEqualStrings("finder", w.role);
     try std.testing.expectEqual(@as(u32, 0), w.tool_calls);
-}
-
-test "telemetry: WorkerMetrics addFileRead/Write" {
-    const alloc = std.testing.allocator;
-    var w = WorkerMetrics.init(alloc, 1, "fixer", "claude-opus-4-6");
-    defer w.deinit(alloc);
-
-    w.addFileRead(alloc, "src/main.zig");
-    w.addFileWritten(alloc, "src/fix.zig");
-
-    try std.testing.expectEqual(@as(usize, 1), w.files_read.items.len);
-    try std.testing.expectEqual(@as(usize, 1), w.files_written.items.len);
-    try std.testing.expectEqualStrings("src/main.zig", w.files_read.items[0]);
 }
 
 test "telemetry: SwarmTelemetry generates valid swarm_id" {
@@ -385,7 +341,7 @@ test "telemetry: SwarmTelemetry toJson produces valid JSON" {
     t.setRepo("owner/repo");
 
     var grid = GridMetrics.init(alloc, "review");
-    var w = WorkerMetrics.init(alloc, 0, "correctness", "claude-sonnet-4-6");
+    var w = WorkerMetrics.init(0, "correctness", "claude-sonnet-4-6");
     w.tokens_in = 4200;
     w.tokens_out = 1800;
     w.wall_ms = 3400;


### PR DESCRIPTION
## Summary
Swarm telemetry shipped in PR #323, but a few parts of the emitted data are currently inaccurate or incomplete.

## Problems

1. `parseMetricsFromOutput` fabricates token telemetry.
   In `src/swarm.zig`, the parser scans for a `"tokens"` number, stores it as `tokens_in`, and then sets `tokens_out = val / 3`. That is not measured usage and can produce misleading telemetry.

2. `files_read` / `files_written` are never populated.
   `WorkerMetrics` exposes `addFileRead` / `addFileWritten`, and the JSON schema includes both arrays, but there are no call sites wiring file access into the swarm telemetry path. As implemented, these arrays are always empty.

3. `telemetry_out` only works with absolute paths.
   The tool schema describes `telemetry_out` as an optional file path, but `src/swarm.zig` uses `std.fs.createFileAbsolute(path, .{})`. Relative paths like `telemetry.json` fail unexpectedly.

4. `WorkerMetrics.init(alloc, ...)` takes an allocator and discards it.
   This is smaller than the above, but it is dead API surface and should either be removed or justified by storing allocator-backed state.

## Proposed fixes

- Replace the token heuristic with real usage data from the runtime/backend when available.
- If real usage is unavailable, leave token fields unset/zero rather than inventing values.
- Either instrument file reads/writes for real, or remove those fields from the schema until wired.
- Accept relative `telemetry_out` paths by resolving against cwd/repo root, or document the parameter as absolute-only.
- Clean up the `WorkerMetrics.init` API.

## Context
- Introduced in PR #323
- Follow-up PR comment: the merged PR discussion now has a review note with the same findings


Closes #334