### PR TITLE
fix hot cache OOM cleanup on insert

### DIFF
--- a/src/graph/hot_cache.zig
+++ b/src/graph/hot_cache.zig
@@ -72,6 +72,7 @@ pub fn LruCache(comptime V: type) type {
 
             // Insert new entry
             const entry = try self.pool.create();
+            errdefer self.pool.destroy(entry);
             entry.* = .{ .key = key, .value = value };
             try self.map.put(key, entry);
             self.pushFront(entry);
@@ -156,6 +157,13 @@ pub const CachedSymbol = struct {
     line: u32,
 };
 
+fn hotCachePutNoLeakOnFailure(allocator: std.mem.Allocator) !void {
+    var cache = LruCache(u32).init(allocator, 4);
+    defer cache.deinit();
+
+    try cache.put(1, 100);
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 test "basic put and get" {
@@ -216,6 +224,10 @@ test "put updates existing key" {
 
     try std.testing.expectEqual(@as(usize, 1), cache.count());
     try std.testing.expectEqual(@as(?u32, 200), cache.get(1));
+}
+
+test "put cleans up pool entry when map.put fails" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, hotCachePutNoLeakOnFailure, .{});
 }
 
 test "remove deletes entry" {


### PR DESCRIPTION
Add errdefer cleanup for pool-created LRU entries before map.put and cover the failure path with checkAllAllocationFailures.

Refs #223
