### PR TITLE
Change orchestrator default model to bolt (gpt-5.4)

### DIFF
--- a/src/runtime/grid.zig
+++ b/src/runtime/grid.zig
@@ -54,7 +54,7 @@ const GridEntry = struct {
 /// Default grid — can be overridden by model_grid.toml.
 const default_grid = [_]GridEntry{
     // Orchestration
-    .{ .role = "orchestrator",  .tier = .opus },
+    .{ .role = "orchestrator",  .tier = .bolt },
     .{ .role = "synthesizer",   .tier = .sonnet },
 
     // Worker roles
@@ -94,14 +94,14 @@ pub fn resolveModel(role: ?[]const u8, mode: AgentMode) []const u8 {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 test "grid: tierForRole returns correct tiers" {
-    try std.testing.expectEqual(ModelTier.opus,   tierForRole("orchestrator").?);
+    try std.testing.expectEqual(ModelTier.bolt,   tierForRole("orchestrator").?);
     try std.testing.expectEqual(ModelTier.sonnet, tierForRole("finder").?);
     try std.testing.expectEqual(ModelTier.haiku,  tierForRole("monitor").?);
     try std.testing.expectEqual(@as(?ModelTier, null), tierForRole("unknown_role"));
 }
 
 test "grid: resolveModel uses grid for known roles" {
-    try std.testing.expectEqualStrings("claude-opus-4-6", resolveModel("orchestrator", .smart));
+    try std.testing.expectEqualStrings("gpt-5.4", resolveModel("orchestrator", .smart));
     try std.testing.expectEqualStrings("claude-sonnet-4-6", resolveModel("finder", .rush));
 }
 

--- a/src/runtime/resolve.zig
+++ b/src/runtime/resolve.zig
@@ -277,7 +277,7 @@ test "resolve: model alias 'opus' expands to full ID" {
 
 test "resolve: grid overrides mode for known roles" {
     const alloc = std.testing.allocator;
-    // orchestrator is opus in grid, even if mode is rush (which defaults to haiku)
+    // orchestrator is bolt in grid, even if mode is rush (which defaults to haiku)
     const req = AgentRequest{ .prompt = "test", .role = "orchestrator", .mode = "rush" };
     const backends = Backends{ .claude = true };
     const tools = ToolAvailability{};
@@ -285,7 +285,7 @@ test "resolve: grid overrides mode for known roles" {
     const r = resolve(alloc, req, backends, tools, null);
     defer prompts.freeAssembled(alloc, r.system_prompt);
 
-    try std.testing.expectEqualStrings("claude-opus-4-6", r.model);
+    try std.testing.expectEqualStrings("gpt-5.4", r.model);
     try std.testing.expectEqual(AgentMode.rush, r.mode);
 }
 


### PR DESCRIPTION
## Summary
- Changes orchestrator grid default from `opus` → `bolt` (gpt-5.4) for stronger task decomposition reasoning
- Updates corresponding tests in `grid.zig` and `resolve.zig`
- Per-project override still available via `.devswarm/config.toml`

## Test plan
- [x] `zig build test` passes locally
- [ ] CI `zig build test` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)