### PR TITLE
Telemetry enrolled by default with transparent onboarding disclosure

### DIFF
--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -320,12 +320,26 @@ fn estimateCost(model: []const u8, tokens_in: u64, tokens_out: u64) f64 {
 
 const DEFAULT_TELEMETRY_URL = "https://devswarm.codegraff.com/v1/telemetry";
 
-/// Check if remote telemetry is enabled. On by default.
-/// Set DEVSWARM_TELEMETRY=false to disable.
+/// Check if remote telemetry is enabled.
+/// Priority: env var DEVSWARM_TELEMETRY → .devswarm/config.toml [telemetry] → default (true).
+/// Enrolled by default. User can opt out via env var or config.
 pub fn isEnabled(alloc: std.mem.Allocator) bool {
-    const val = std.process.getEnvVarOwned(alloc, "DEVSWARM_TELEMETRY") catch return true;
-    defer alloc.free(val);
-    return !std.mem.eql(u8, val, "false") and !std.mem.eql(u8, val, "0") and !std.mem.eql(u8, val, "off");
+    // 1. Env var override (highest priority)
+    if (std.process.getEnvVarOwned(alloc, "DEVSWARM_TELEMETRY")) |val| {
+        defer alloc.free(val);
+        return !std.mem.eql(u8, val, "false") and !std.mem.eql(u8, val, "0") and !std.mem.eql(u8, val, "off");
+    } else |_| {}
+
+    // 2. Check .devswarm/config.toml for [telemetry] enabled = false
+    if (std.fs.cwd().readFileAlloc(alloc, ".devswarm/config.toml", 64 * 1024)) |content| {
+        defer alloc.free(content);
+        if (std.mem.indexOf(u8, content, "enabled = false") != null or
+            std.mem.indexOf(u8, content, "enabled=false") != null)
+            return false;
+    } else |_| {}
+
+    // 3. Default: enabled
+    return true;
 }
 
 /// Upload telemetry JSON to the backend. Strips the task field for privacy.

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -2792,6 +2792,24 @@ fn handleOnboard(alloc: std.mem.Allocator, _: *const std.json.ObjectMap, out: *s
     // Create .devswarm/ directory if needed
     std.fs.cwd().makePath(".devswarm") catch {};
 
+    // Write telemetry config (enrolled by default, user can opt out)
+    if (!has_config) {
+        const cfg_file = std.fs.cwd().createFile(".devswarm/config.toml", .{}) catch null;
+        if (cfg_file) |f| {
+            defer f.close();
+            f.writeAll(
+                "# devswarm configuration\n" ++
+                "# See: https://github.com/justrach/devswarm\n\n" ++
+                "[telemetry]\n" ++
+                "# Anonymous usage telemetry helps improve devswarm.\n" ++
+                "# What's sent: agent roles, model names, token counts, wall time, cost.\n" ++
+                "# What's NEVER sent: code, file contents, prompts, repo names, branch names.\n" ++
+                "# Set to false to opt out at any time.\n" ++
+                "enabled = true\n",
+            ) catch {};
+        }
+    }
+
     // Write the onboarded marker
     const marker_file = std.fs.cwd().createFile(ONBOARD_MARKER, .{}) catch {
         writeErr(alloc, out, "failed to create .devswarm/onboarded marker");
@@ -2830,7 +2848,9 @@ fn handleOnboard(alloc: std.mem.Allocator, _: *const std.json.ObjectMap, out: *s
     }
     out.appendSlice(alloc, " now available. The onboard tool has been removed — you will not see it again.\"") catch return;
 
-    out.appendSlice(alloc, ",\"next_steps\":[\"Use run_swarm for parallel multi-agent tasks\",\"Use run_task for sequential agent chains\",\"Drop .md files in .devswarm/skills/ to add custom roles\"]") catch return;
+    out.appendSlice(alloc, ",\"telemetry\":{\"enabled\":true,\"what_is_sent\":\"agent roles, model names, token counts, wall time, cost\",\"what_is_never_sent\":\"code, file contents, prompts, repo names, branch names\",\"opt_out\":\"Set enabled = false in .devswarm/config.toml or DEVSWARM_TELEMETRY=false\"}") catch return;
+
+    out.appendSlice(alloc, ",\"next_steps\":[\"Use run_swarm for parallel multi-agent tasks\",\"Use run_task for sequential agent chains\",\"Drop .md files in .devswarm/skills/ to add custom roles\",\"Edit .devswarm/config.toml to configure roles or disable telemetry\"]") catch return;
 
     out.appendSlice(alloc, "}") catch return;
 }


### PR DESCRIPTION
## Summary

Telemetry is now opt-out (enrolled by default) with full transparency during onboarding.

### What happens on first run (`onboard` tool)
1. Creates `.devswarm/config.toml` with `[telemetry] enabled = true`
2. Config file includes clear comments explaining what IS and ISN'T sent
3. Onboard response includes `telemetry` field with disclosure

### Generated `.devswarm/config.toml`
```toml
[telemetry]
# Anonymous usage telemetry helps improve devswarm.
# What's sent: agent roles, model names, token counts, wall time, cost.
# What's NEVER sent: code, file contents, prompts, repo names, branch names.
# Set to false to opt out at any time.
enabled = true
```

### Opt-out (any time)
- Edit `.devswarm/config.toml`: `enabled = false`
- Or env var: `DEVSWARM_TELEMETRY=false`

### `isEnabled()` priority chain
1. `DEVSWARM_TELEMETRY` env var (highest)
2. `.devswarm/config.toml` `[telemetry] enabled`
3. Default: `true`

## Test plan
- [x] `zig build test` passes
- [x] `zig build` succeeds
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)