### PR TITLE
Fix: route gpt-* models to Codex backend

### DIFF
--- a/src/runtime/resolve.zig
+++ b/src/runtime/resolve.zig
@@ -101,8 +101,9 @@ pub fn resolve(
     //    Priority: explicit codex model → config [agents.<role>].backend
     //              → config [provider].primary → probed preferred
     const backend: Backend = blk: {
-        // If model is explicitly a Codex model, use codex backend
-        if (std.mem.indexOf(u8, model, "codex") != null and backends.codex)
+        // If model is a Codex/OpenAI model, use codex backend
+        if ((std.mem.indexOf(u8, model, "codex") != null or
+            std.mem.indexOf(u8, model, "gpt-") != null) and backends.codex)
             break :blk .codex;
         // config.toml per-role backend override
         if (role_cfg) |rc| {


### PR DESCRIPTION
Backend resolver only checked for "codex" in model name. gpt-5.4 (orchestrator's bolt tier) was routed to Claude CLI which can't run it. Now also checks for "gpt-" prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)