### PR TITLE
Capture token usage + auto-detect repo in telemetry

### DIFF
--- a/src/agent_sdk.zig
+++ b/src/agent_sdk.zig
@@ -236,11 +236,30 @@ fn parseClaudeLine(
     };
 
     if (std.mem.eql(u8, type_str, "result")) {
-        // {"type":"result","subtype":"success","result":"<final text>",...}
+        // {"type":"result","subtype":"success","result":"<final text>","usage":{...},...}
         if (obj.get("result")) |rv| {
             if (rv == .string) {
                 out.appendSlice(alloc, rv.string) catch {};
                 found_result.* = true;
+            }
+        }
+        // Append usage metadata as a trailing marker for telemetry extraction
+        if (obj.get("usage")) |usage_v| {
+            if (usage_v == .object) {
+                var buf: [128]u8 = undefined;
+                const in_tok = if (usage_v.object.get("input_tokens")) |v| switch (v) {
+                    .integer => |i| @as(u64, @intCast(i)),
+                    else => @as(u64, 0),
+                } else 0;
+                const out_tok = if (usage_v.object.get("output_tokens")) |v| switch (v) {
+                    .integer => |i| @as(u64, @intCast(i)),
+                    else => @as(u64, 0),
+                } else 0;
+                const marker = std.fmt.bufPrint(&buf,
+                    "\n__USAGE__:tokens_in={d},tokens_out={d}",
+                    .{ in_tok, out_tok },
+                ) catch "";
+                out.appendSlice(alloc, marker) catch {};
             }
         }
     } else if (std.mem.eql(u8, type_str, "assistant")) {

--- a/src/swarm.zig
+++ b/src/swarm.zig
@@ -66,30 +66,33 @@ fn workerFn(args: *WorkerArgs) void {
 }
 
 fn parseMetricsFromOutput(_: std.mem.Allocator, output: []const u8, metrics: *telemetry.WorkerMetrics) void {
-    var i: usize = 0;
-    while (i < output.len) {
-        if (std.mem.indexOfPos(u8, output, i, "\"tokens\"")) |tok_pos| {
-            i = tok_pos + 9;
-            while (i < output.len and output[i] != '{' and output[i] != ':') i += 1;
-            if (i < output.len and output[i] == ':') {
-                i += 1;
-                while (i < output.len and (output[i] == ' ' or output[i] == '\t')) i += 1;
-                const start = i;
-                while (i < output.len and output[i] >= '0' and output[i] <= '9') i += 1;
-                if (i > start) {
-                    const num_str = output[start..i];
-                    if (std.fmt.parseInt(u64, num_str, 10)) |val| {
-                        metrics.tokens_in = val;
-                    } else |_| {}
-                }
+    // Parse __USAGE__ marker appended by agent_sdk.zig
+    // Format: \n__USAGE__:tokens_in=N,tokens_out=N
+    if (std.mem.indexOf(u8, output, "__USAGE__:")) |marker_pos| {
+        const after = output[marker_pos + 10 ..]; // skip "__USAGE__:"
+        // Parse tokens_in
+        if (std.mem.indexOf(u8, after, "tokens_in=")) |ti_pos| {
+            const num_start = ti_pos + 10;
+            var num_end = num_start;
+            while (num_end < after.len and after[num_end] >= '0' and after[num_end] <= '9') num_end += 1;
+            if (num_end > num_start) {
+                metrics.tokens_in = std.fmt.parseInt(u64, after[num_start..num_end], 10) catch 0;
             }
-        } else {
-            break;
+        }
+        // Parse tokens_out
+        if (std.mem.indexOf(u8, after, "tokens_out=")) |to_pos| {
+            const num_start = to_pos + 11;
+            var num_end = num_start;
+            while (num_end < after.len and after[num_end] >= '0' and after[num_end] <= '9') num_end += 1;
+            if (num_end > num_start) {
+                metrics.tokens_out = std.fmt.parseInt(u64, after[num_start..num_end], 10) catch 0;
+            }
         }
     }
 
+    // Count tool_use occurrences
     var tool_count: u32 = 0;
-    i = 0;
+    var i: usize = 0;
     while (i < output.len) {
         if (std.mem.indexOfPos(u8, output, i, "tool_use")) |tu| {
             tool_count += 1;
@@ -235,6 +238,13 @@ pub fn runSwarm(
     var swarm_telemetry = telemetry.SwarmTelemetry.init(alloc, task);
     defer swarm_telemetry.deinit();
     swarm_telemetry.parallelism_theoretical = @intCast(cap);
+
+    // Auto-detect repo for telemetry
+    if (@import("gh.zig").run(alloc, &.{ "git", "remote", "get-url", "origin" })) |r| {
+        defer r.deinit(alloc);
+        const trimmed = std.mem.trim(u8, r.stdout, " \t\n\r");
+        if (trimmed.len > 0) swarm_telemetry.setRepo(trimmed);
+    } else |_| {}
 
     var count: usize = 0;
 


### PR DESCRIPTION
Telemetry was showing tokens=0 and repo=null for all swarms. Fixed:

- `agent_sdk.zig`: extracts `usage.input_tokens`/`output_tokens` from Claude CLI `result` event, appends `__USAGE__` marker
- `swarm.zig`: `parseMetricsFromOutput` parses the marker for real token counts
- `swarm.zig`: auto-detects repo via `git remote get-url origin` at swarm startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)