### PR TITLE
Add success/failure tracking to worker telemetry

### DIFF
--- a/src/swarm.zig
+++ b/src/swarm.zig
@@ -63,6 +63,12 @@ fn workerFn(args: *WorkerArgs) void {
     args.metrics.*.wall_ms = @intCast(@max(0, args.worker.end_ms - args.worker.start_ms));
 
     parseMetricsFromOutput(alloc, args.worker.out.items, args.metrics);
+
+    // Mark success: non-empty output that isn't an error/timeout JSON
+    const out_trimmed = std.mem.trim(u8, args.worker.out.items, " \t\n\r");
+    args.metrics.*.success = out_trimmed.len > 0 and
+        !std.mem.startsWith(u8, out_trimmed, "{\"error\"") and
+        !std.mem.startsWith(u8, out_trimmed, "{\"timed_out\"");
 }
 
 fn parseMetricsFromOutput(_: std.mem.Allocator, output: []const u8, metrics: *telemetry.WorkerMetrics) void {

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -10,6 +10,7 @@ pub const WorkerMetrics = struct {
     tokens_out: u64 = 0,
     wall_ms: u64 = 0,
     errors: u32 = 0,
+    success: bool = false,  // true if worker produced non-empty, non-error output
 
     pub fn init(id: u32, role: []const u8, model: []const u8) WorkerMetrics {
         return .{
@@ -289,6 +290,9 @@ pub const SwarmTelemetry = struct {
         buf.appendSlice(alloc, ",\"errors\":") catch return;
         const err_str = std.fmt.bufPrint(&tmp, "{d}", .{w.errors}) catch "";
         buf.appendSlice(alloc, err_str) catch return;
+
+        buf.appendSlice(alloc, ",\"success\":") catch return;
+        buf.appendSlice(alloc, if (w.success) "true" else "false") catch return;
 
         buf.appendSlice(alloc, "}") catch return;
     }


### PR DESCRIPTION
Adds success field to WorkerMetrics. Now telemetry has cost + tokens + success per role — enough to evolve the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)