### PR TITLE
Fix #374 #376: --no-mcp-servers for workers + cached config

### DIFF
--- a/src/agent_sdk.zig
+++ b/src/agent_sdk.zig
@@ -93,6 +93,7 @@ pub fn tryClaudeAgent(
     argv_buf[argc] = perm_mode;           argc += 1;
     argv_buf[argc] = "--model";          argc += 1;
     argv_buf[argc] = model;              argc += 1;
+    argv_buf[argc] = "--no-mcp-servers"; argc += 1;
 
     if (opts.reasoning_effort) |effort| {
         argv_buf[argc] = "--reasoning-effort"; argc += 1;
@@ -183,12 +184,12 @@ fn streamClaudeOutput(
     var total_in: u64 = 0;
     var total_out: u64 = 0;
 
+
     while (!found_result) {
         const line = readLine(alloc, file) orelse break;
         defer alloc.free(line);
         parseClaudeLine(alloc, line, out, &accumulated, &found_result, &total_in, &total_out);
     }
-
     if (!found_result and accumulated.items.len > 0) {
         out.appendSlice(alloc, accumulated.items) catch {};
     }

--- a/src/runtime/resolve.zig
+++ b/src/runtime/resolve.zig
@@ -178,17 +178,34 @@ pub fn resolve(
     };
 }
 
+// ── Cached config (loaded once per process, reused safely across calls) ────────
+
+var g_cfg_mu: std.Thread.Mutex = .{};
+var g_cfg_probed: bool = false;
+var g_cfg: ?config.Config = null;
+
+fn getCachedConfig() ?*const config.Config {
+    g_cfg_mu.lock();
+    defer g_cfg_mu.unlock();
+    if (!g_cfg_probed) {
+        g_cfg = config.loadDefault(std.heap.page_allocator);
+        g_cfg_probed = true;
+    }
+    if (g_cfg) |*c| return c;
+    return null;
+}
+
 /// Convenience: resolve with live-probed backends, tools, and default config.
+/// Config is loaded from disk once and cached for all subsequent calls.
 pub fn resolveWithProbe(alloc: std.mem.Allocator, request: AgentRequest) ResolvedAgent {
     const backends = detect.probe(alloc);
     const tools = cascade.probe(alloc);
-    var cfg = config.loadDefault(alloc);
+    const cfg: ?config.Config = if (getCachedConfig()) |cp| cp.* else null;
     var result = resolve(alloc, request, backends, tools, cfg);
     // model may point into cfg-owned memory (expandAlias returns full model IDs
-    // unchanged — same pointer into cfg's heap).  Dupe it before freeing cfg so
-    // the returned ResolvedAgent owns its model string independently of cfg.
+    // unchanged — same pointer into cfg's heap).  Dupe it so the returned
+    // ResolvedAgent owns its model string independently of the cached cfg.
     result.model = alloc.dupe(u8, result.model) catch unreachable;
-    if (cfg) |*c| c.deinit(alloc);
     return result;
 }
 


### PR DESCRIPTION
Two fixes found and applied by run_swarm self-review:

- **#374 (P0):** `--no-mcp-servers` added to Claude CLI args so workers use built-in tools only. Fixes the #1 cause of worker failures.
- **#376 (P1):** Config cached globally (mutex, read-once). Eliminates N+2 disk reads per swarm.

Buffered reader (#375) deferred — Zig 0.15 API changed, needs separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)