### PR TITLE
Fix: use --bare for worker isolation instead of invalid --no-mcp-servers

### DIFF
--- a/src/agent_sdk.zig
+++ b/src/agent_sdk.zig
@@ -93,7 +93,7 @@ pub fn tryClaudeAgent(
     argv_buf[argc] = perm_mode;           argc += 1;
     argv_buf[argc] = "--model";          argc += 1;
     argv_buf[argc] = model;              argc += 1;
-    argv_buf[argc] = "--no-mcp-servers"; argc += 1;
+    argv_buf[argc] = "--bare";            argc += 1;
 
     if (opts.reasoning_effort) |effort| {
         argv_buf[argc] = "--reasoning-effort"; argc += 1;


### PR DESCRIPTION
--no-mcp-servers doesn't exist. --bare skips all MCP, hooks, plugins — clean worker execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)