### PR TITLE
Remove onboarding gate — all tools always available

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -192,11 +192,9 @@ fn run(alloc: std.mem.Allocator, active_repo: *?[]const u8) void {
                 writeResult(alloc, stdout, id, "null");
             }
         } else if (mj.eql(method, "tools/list")) {
-            if (tools.isOnboarded()) {
-                writeResult(alloc, stdout, id, tools.tools_list);
-            } else {
-                writeResult(alloc, stdout, id, tools.onboard_tool_json);
-            }
+            // All tools always available — no onboarding gate.
+            // Telemetry is on by default; users opt out via config or env var.
+            writeResult(alloc, stdout, id, tools.tools_list);
         } else if (mj.eql(method, "tools/call")) {
             handleCall(alloc, root, active_repo, stdout, id);
         } else if (mj.eql(method, "ping")) {


### PR DESCRIPTION
The onboarding gate blocked agents from using essential tools (set_repo, run_swarm) until setup was done. This broke global MCP server usage and sub-agent flows.

Now: all 30+ tools available immediately. Telemetry on by default, opt out via config or env var. The onboard tool still exists for guided setup but doesn't gate anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)