### PR TITLE
Remove onboard tool — telemetry on by default, no gate

### DIFF
--- a/src/tools.zig
+++ b/src/tools.zig
@@ -177,8 +177,6 @@ pub const Tool = enum {
     run_agent,
     // Smart executor — picks strategy, roles, and models automatically
     run_task,
-    // Onboarding — self-deregisters after first run
-    onboard,
 };
 
 // ── Step 2: Tool schemas ──────────────────────────────────────────────────────
@@ -292,8 +290,6 @@ pub fn dispatch(
         .run_agent => handleRunAgent(alloc, args, out),
         // Smart executor
         .run_task => handleRunTask(alloc, args, out),
-        // Onboarding
-        .onboard => handleOnboard(alloc, args, out),
     }
 }
 
@@ -2755,138 +2751,4 @@ fn handleRunTask(
     }
 
     out.appendSlice(alloc, "]}") catch return;
-}
-
-// ── Onboarding ────────────────────────────────────────────────────────────────
-
-const ONBOARD_MARKER = ".devswarm/onboarded";
-
-/// Check if the project has been onboarded.
-pub fn isOnboarded() bool {
-    std.fs.cwd().access(ONBOARD_MARKER, .{}) catch return false;
-    return true;
-}
-
-/// Onboard tool JSON schema (shown only when not onboarded).
-pub const onboard_tool_json =
-    \\{"tools":[
-    \\{"name":"onboard","description":"Set up devswarm for this project. Discovers your codebase, available skills, and configures quality preferences. This tool disappears after setup is complete — you will not see it again.","inputSchema":{"type":"object","properties":{},"required":[]}},
-    \\{"name":"get_project_state","description":"Return all open issues grouped by status label, all open branches, and all open PRs. Use this to understand current project state before picking up work.","inputSchema":{"type":"object","properties":{},"required":[]}},
-    \\{"name":"set_repo","description":"Switch the active repository path. Call this FIRST if devswarm is pointing at the wrong project. All subsequent tool calls will operate against this repo.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to the git repository root"}},"required":["path"]}}
-    \\]}
-;
-
-fn handleOnboard(alloc: std.mem.Allocator, _: *const std.json.ObjectMap, out: *std.ArrayList(u8)) void {
-    const skills_mod = @import("skills.zig");
-
-    // Discover project info
-    var repo_name: []const u8 = "unknown";
-    var repo_alloc: ?[]u8 = null;
-    defer if (repo_alloc) |r| alloc.free(r);
-    if (gh.run(alloc, &.{ "git", "remote", "get-url", "origin" })) |r| {
-        defer r.deinit(alloc);
-        const trimmed = std.mem.trim(u8, r.stdout, " \t\n\r");
-        if (trimmed.len > 0) {
-            repo_alloc = alloc.dupe(u8, trimmed) catch null;
-            if (repo_alloc) |ra| repo_name = ra;
-        }
-    } else |_| {}
-
-    // Discover skills
-    var skill_count: usize = 0;
-    var skill_names_buf: [512]u8 = undefined;
-    var skill_names_len: usize = 0;
-    if (skills_mod.discover(alloc)) |*set| {
-        defer @constCast(set).deinit();
-        skill_count = set.skills.count();
-        var it = set.skills.iterator();
-        while (it.next()) |entry| {
-            if (skill_names_len > 0 and skill_names_len + 2 < skill_names_buf.len) {
-                skill_names_buf[skill_names_len] = ',';
-                skill_names_buf[skill_names_len + 1] = ' ';
-                skill_names_len += 2;
-            }
-            const name = entry.key_ptr.*;
-            if (skill_names_len + name.len <= skill_names_buf.len) {
-                @memcpy(skill_names_buf[skill_names_len..][0..name.len], name);
-                skill_names_len += name.len;
-            }
-        }
-    }
-    const skill_names = if (skill_names_len > 0) skill_names_buf[0..skill_names_len] else "none";
-
-    // Count built-in roles
-    const roles_mod = @import("runtime.zig").roles;
-    const builtin_count = roles_mod.allRoleNames().len;
-
-    // Check for existing config
-    const has_config = blk: {
-        std.fs.cwd().access(".devswarm/config.toml", .{}) catch break :blk false;
-        break :blk true;
-    };
-
-    // Create .devswarm/ directory if needed
-    std.fs.cwd().makePath(".devswarm") catch {};
-
-    // Write telemetry config (enrolled by default, user can opt out)
-    if (!has_config) {
-        const cfg_file = std.fs.cwd().createFile(".devswarm/config.toml", .{}) catch null;
-        if (cfg_file) |f| {
-            defer f.close();
-            f.writeAll(
-                "# devswarm configuration\n" ++
-                "# See: https://github.com/justrach/devswarm\n\n" ++
-                "[telemetry]\n" ++
-                "# Anonymous usage telemetry helps improve devswarm.\n" ++
-                "# What's sent: agent roles, model names, token counts, wall time, cost.\n" ++
-                "# What's NEVER sent: code, file contents, prompts, repo names, branch names.\n" ++
-                "# Set to false to opt out at any time.\n" ++
-                "enabled = true\n",
-            ) catch {};
-        }
-    }
-
-    // Write the onboarded marker
-    const marker_file = std.fs.cwd().createFile(ONBOARD_MARKER, .{}) catch {
-        writeErr(alloc, out, "failed to create .devswarm/onboarded marker");
-        return;
-    };
-    marker_file.close();
-
-    // Build response JSON
-    out.appendSlice(alloc, "{\"onboarded\":true") catch return;
-
-    out.appendSlice(alloc, ",\"project\":{\"repo\":\"") catch return;
-    mj.writeEscaped(alloc, out, repo_name);
-    out.appendSlice(alloc, "\"}") catch return;
-
-    out.appendSlice(alloc, ",\"roles\":{\"built_in\":") catch return;
-    var count_buf: [8]u8 = undefined;
-    out.appendSlice(alloc, std.fmt.bufPrint(&count_buf, "{d}", .{builtin_count}) catch "0") catch return;
-
-    out.appendSlice(alloc, ",\"discovered_skills\":") catch return;
-    out.appendSlice(alloc, std.fmt.bufPrint(&count_buf, "{d}", .{skill_count}) catch "0") catch return;
-
-    out.appendSlice(alloc, ",\"skill_names\":\"") catch return;
-    mj.writeEscaped(alloc, out, skill_names);
-    out.appendSlice(alloc, "\"}") catch return;
-
-    out.appendSlice(alloc, ",\"has_config\":") catch return;
-    out.appendSlice(alloc, if (has_config) "true" else "false") catch return;
-
-    out.appendSlice(alloc, ",\"message\":\"Setup complete. ") catch return;
-    out.appendSlice(alloc, std.fmt.bufPrint(&count_buf, "{d}", .{builtin_count}) catch "?") catch return;
-    out.appendSlice(alloc, " built-in roles") catch return;
-    if (skill_count > 0) {
-        out.appendSlice(alloc, " + ") catch return;
-        out.appendSlice(alloc, std.fmt.bufPrint(&count_buf, "{d}", .{skill_count}) catch "?") catch return;
-        out.appendSlice(alloc, " custom skills") catch return;
-    }
-    out.appendSlice(alloc, " now available. The onboard tool has been removed — you will not see it again.\"") catch return;
-
-    out.appendSlice(alloc, ",\"telemetry\":{\"enabled\":true,\"what_is_sent\":\"agent roles, model names, token counts, wall time, cost\",\"what_is_never_sent\":\"code, file contents, prompts, repo names, branch names\",\"opt_out\":\"Set enabled = false in .devswarm/config.toml or DEVSWARM_TELEMETRY=false\"}") catch return;
-
-    out.appendSlice(alloc, ",\"next_steps\":[\"Use run_swarm for parallel multi-agent tasks\",\"Use run_task for sequential agent chains\",\"Drop .md files in .devswarm/skills/ to add custom roles\",\"Edit .devswarm/config.toml to configure roles or disable telemetry\"]") catch return;
-
-    out.appendSlice(alloc, "}") catch return;
 }


### PR DESCRIPTION
Removes the onboard tool entirely. It conflicted with set_repo, blocked agents, and required auth sub-agents don't have.

All 30+ tools always available. Telemetry on by default, opt out via env var or config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)