### PR TITLE
Fix #374: --strict-mcp-config for worker isolation (keeps auth)

### DIFF
--- a/src/agent_sdk.zig
+++ b/src/agent_sdk.zig
@@ -93,7 +93,8 @@ pub fn tryClaudeAgent(
     argv_buf[argc] = perm_mode;           argc += 1;
     argv_buf[argc] = "--model";          argc += 1;
     argv_buf[argc] = model;              argc += 1;
-    argv_buf[argc] = "--bare";            argc += 1;
+    argv_buf[argc] = "--strict-mcp-config"; argc += 1;
+    argv_buf[argc] = "{}";                  argc += 1;
 
     if (opts.reasoning_effort) |effort| {
         argv_buf[argc] = "--reasoning-effort"; argc += 1;


### PR DESCRIPTION
--bare broke auth. --strict-mcp-config {} blocks MCP servers while keeping OAuth/keychain login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)