### PR TITLE
Fix #226, #225, #224, #166: WAL safety, IPC socket, watcher, PPR

### DIFF
--- a/src/graph/ipc.zig
+++ b/src/graph/ipc.zig
@@ -84,6 +84,7 @@ pub const Server = struct {
     alloc: std.mem.Allocator,
     handler: Handler,
     running: bool,
+    bound_path: []const u8,
 
     /// Create a server listening on the given Unix socket path.
     pub fn listen(path: []const u8, handler: Handler, alloc: std.mem.Allocator) !Server {
@@ -95,6 +96,9 @@ pub const Server = struct {
             std.fs.cwd().makePath(dir) catch {};
         }
 
+        const bound_path = try alloc.dupe(u8, path);
+        errdefer alloc.free(bound_path);
+
         const addr = std.net.Address.initUnix(path) catch return error.InvalidSocketPath;
         const socket = try addr.listen(.{});
 
@@ -103,6 +107,7 @@ pub const Server = struct {
             .alloc = alloc,
             .handler = handler,
             .running = true,
+            .bound_path = bound_path,
         };
     }
 
@@ -138,8 +143,9 @@ pub const Server = struct {
 
     pub fn deinit(self: *Server) void {
         self.socket.deinit();
-        // Clean up socket file
-        std.fs.cwd().deleteFile(SOCKET_PATH) catch {};
+        // Clean up socket file using the actual bound path
+        std.fs.cwd().deleteFile(self.bound_path) catch {};
+        self.alloc.free(self.bound_path);
     }
 };
 
@@ -343,4 +349,76 @@ test "multiple frames with varying sizes" {
     const f3 = try readFrame(stream.reader(), std.testing.allocator);
     defer std.testing.allocator.free(f3);
     try std.testing.expectEqualStrings("hello world, this is a longer frame payload for testing", f3);
+}
+
+// ── Server bound_path regression tests ──────────────────────────────────────
+
+test "Server.deinit removes actual bound path not SOCKET_PATH" {
+    // Bind to a custom temp path and verify deinit removes that file, not
+    // the hardcoded SOCKET_PATH constant.
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Build an absolute socket path inside the temp dir.
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_abs = try tmp.dir.realpath(".", &path_buf);
+    const sock_path = try std.fmt.allocPrint(alloc, "{s}/test.sock", .{tmp_abs});
+    defer alloc.free(sock_path);
+
+    // Dummy handler — never called in this test.
+    const noop: Handler = struct {
+        fn h(_: []const u8, _: std.mem.Allocator) ?[]u8 {
+            return null;
+        }
+    }.h;
+
+    var srv = try Server.listen(sock_path, noop, alloc);
+
+    // Socket file must exist after listen.
+    tmp.dir.access("test.sock", .{}) catch |err| {
+        std.debug.panic("socket file missing after listen: {}", .{err});
+    };
+
+    // deinit must remove the actual bound path.
+    srv.deinit();
+
+    // Socket file must be gone.
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("test.sock", .{}));
+
+    // SOCKET_PATH must NOT have been deleted (it was never created here).
+    // We simply verify the default constant differs from our custom path.
+    try std.testing.expect(!std.mem.eql(u8, sock_path, SOCKET_PATH));
+}
+
+test "Server.deinit uses bound_path stored at listen time" {
+    // Verify that the bound_path field reflects the path passed to listen,
+    // independent of the SOCKET_PATH constant.
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_abs = try tmp.dir.realpath(".", &path_buf);
+    const sock_path = try std.fmt.allocPrint(alloc, "{s}/alt.sock", .{tmp_abs});
+    defer alloc.free(sock_path);
+
+    const noop: Handler = struct {
+        fn h(_: []const u8, _: std.mem.Allocator) ?[]u8 {
+            return null;
+        }
+    }.h;
+
+    var srv = try Server.listen(sock_path, noop, alloc);
+
+    // bound_path must equal the path we passed, not SOCKET_PATH.
+    try std.testing.expectEqualStrings(sock_path, srv.bound_path);
+    try std.testing.expect(!std.mem.eql(u8, srv.bound_path, SOCKET_PATH));
+
+    srv.deinit();
+
+    // File must be cleaned up.
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("alt.sock", .{}));
 }

--- a/src/graph/ppr_incremental.zig
+++ b/src/graph/ppr_incremental.zig
@@ -75,22 +75,26 @@ pub const IncrementalPpr = struct {
     /// Notify that an edge was added from src to dst with the given weight.
     /// Injects residual at the source node so the next deltaUpdate propagates
     /// the score change through the new edge.
+    /// Notify that an edge was added from src to dst with the given weight.
+    /// Un-absorbs src's current score back to residual so that the next
+    /// deltaUpdate re-pushes it through the updated edge list (including the
+    /// new edge), faithfully applying the push rule:
+    ///   r[v] += (1-α)·r[u]·W(u,v)/W_out(u)
     pub fn onEdgeAdded(self: *IncrementalPpr, src: u64, dst: u64, weight: f32) !void {
         _ = dst;
-        // The source node's outgoing weight distribution changed, so its
-        // current score needs to be partially redistributed. We inject
-        // residual proportional to the source's current score and the
-        // weight of the new edge, scaled by (1-alpha).
-        const src_score = self.scores.get(src) orelse 0;
-        const injection = (1.0 - self.alpha) * src_score * weight;
-
-        if (injection > 0) {
-            const entry = try self.residuals.getOrPut(src);
-            if (!entry.found_existing) entry.value_ptr.* = 0;
-            entry.value_ptr.* += injection;
+        // A zero-weight edge does not change any distribution; skip injection.
+        if (weight > 0) {
+            // Un-absorb src's score back to residual so deltaUpdate re-pushes
+            // through the updated edge list with proper W_out normalisation.
+            const src_score = self.scores.get(src) orelse 0;
+            if (src_score > 0) {
+                const entry = try self.residuals.getOrPut(src);
+                if (!entry.found_existing) entry.value_ptr.* = 0;
+                entry.value_ptr.* += src_score;
+                self.scores.putAssumeCapacity(src, 0);
+            }
         }
-
-        // Mark source as dirty regardless (edge topology changed)
+        // Mark source dirty regardless (edge topology changed).
         try self.dirty_nodes.put(src, {});
     }
 
@@ -102,31 +106,32 @@ pub const IncrementalPpr = struct {
     /// Marks the source node dirty so deltaUpdate can recompute its local
     /// neighbourhood. Also redistributes the score that was flowing through
     /// the removed edge back as residual on the source.
+    /// Notify that an edge from src to dst was removed.
+    /// Un-absorbs both src's and dst's current scores back to residual so
+    /// that the next deltaUpdate re-pushes them through the updated topology,
+    /// faithfully applying the push rule with no edge from src to dst.
     pub fn onEdgeRemoved(self: *IncrementalPpr, src: u64, dst: u64) !void {
-        // The score that was flowing to dst through this edge needs to be
-        // reclaimed. We approximate by marking both nodes dirty and injecting
-        // residual at the source.
+        // Un-absorb src's score: deltaUpdate will re-push through remaining
+        // edges only (the removed edge is gone), applying the push rule with
+        // the correct updated W_out normalisation.
         const src_score = self.scores.get(src) orelse 0;
-        const dst_score = self.scores.get(dst) orelse 0;
-
-        // Inject residual at source proportional to its score
         if (src_score > 0) {
             const entry = try self.residuals.getOrPut(src);
             if (!entry.found_existing) entry.value_ptr.* = 0;
-            entry.value_ptr.* += (1.0 - self.alpha) * src_score;
+            entry.value_ptr.* += src_score;
+            self.scores.putAssumeCapacity(src, 0);
         }
 
-        // Reduce dst score (it was partially derived from the removed edge)
-        // and convert to residual for redistribution
+        // Un-absorb dst's score: dst was receiving flow through the removed
+        // edge; returning its absorbed score to residual lets deltaUpdate
+        // redistribute it through dst's own out-edges with the updated
+        // topology (no arbitrary 0.5 estimate).
+        const dst_score = self.scores.get(dst) orelse 0;
         if (dst_score > 0) {
-            const reduction = dst_score * 0.5; // conservative estimate
-            if (self.scores.getPtr(dst)) |ptr| {
-                ptr.* -= reduction;
-                if (ptr.* < 0) ptr.* = 0;
-            }
             const dst_entry = try self.residuals.getOrPut(dst);
             if (!dst_entry.found_existing) dst_entry.value_ptr.* = 0;
-            dst_entry.value_ptr.* += reduction;
+            dst_entry.value_ptr.* += dst_score;
+            self.scores.putAssumeCapacity(dst, 0);
         }
 
         try self.dirty_nodes.put(src, {});
@@ -575,8 +580,8 @@ test "onEdgeAdded with weight=0 does not inject residual" {
 
     try ippr.onEdgeAdded(1, 2, 0.0);
 
-    // injection = (1-alpha) * 0.5 * 0.0 = 0, so no residual injected
-    // But dirty node is still marked
+    // weight=0 does not change any distribution; no residual injected.
+    // But dirty node is still marked.
     try std.testing.expectEqual(@as(usize, 1), ippr.dirtyCount());
     // Residual should be null or 0
     const r = ippr.residuals.get(1);
@@ -603,17 +608,18 @@ test "multiple rapid edge additions accumulate residual" {
 
     try ippr.scores.put(1, 1.0);
 
-    // Add 5 edges rapidly from same source
+    // Add 5 edges rapidly from the same source.
+    // The first call un-absorbs p[1]=1.0 into residual and zeros p[1].
+    // Subsequent calls see p[1]=0 and inject nothing (no double-counting).
     try ippr.onEdgeAdded(1, 10, 1.0);
     try ippr.onEdgeAdded(1, 11, 1.0);
     try ippr.onEdgeAdded(1, 12, 1.0);
     try ippr.onEdgeAdded(1, 13, 1.0);
     try ippr.onEdgeAdded(1, 14, 1.0);
 
-    // Each injection adds (1-alpha)*score*weight to residual
-    // Total = 5 * (1-0.15) * 1.0 * 1.0 = 4.25
+    // Residual equals the original score (un-absorbed once, not five times).
     const r = ippr.residuals.get(1) orelse 0;
-    try std.testing.expectApproxEqAbs(@as(f32, 4.25), r, 1e-4);
+    try std.testing.expectApproxEqAbs(@as(f32, 1.0), r, 1e-6);
 }
 
 test "onFileInvalidated with empty symbol list" {
@@ -721,4 +727,122 @@ test "deltaUpdate with self-loop preserves residual correctly" {
     try std.testing.expect(score > 0.5); // must be well above alpha
     try std.testing.expectApproxEqAbs(@as(f32, 1.0), score, 0.1);
     try std.testing.expectEqual(@as(usize, 0), ippr.dirtyCount());
+}
+
+// ── Regression tests: incremental vs full PPR ────────────────────────────────
+
+test "regression: incremental from scratch matches full PPR" {
+    const ppr_mod = @import("ppr.zig");
+    var g = makeTestGraph(std.testing.allocator);
+    defer g.deinit();
+
+    // Chain: 1 -> 2 -> 3
+    try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+    try g.addEdge(.{ .src = 2, .dst = 3, .kind = .calls });
+
+    // Full batch PPR from query node 1
+    var full = try ppr_mod.pprPush(&g, 1, DEFAULT_ALPHA, DEFAULT_EPSILON, std.testing.allocator);
+    defer full.deinit();
+
+    // Incremental from scratch: seed residual r[1]=1.0, run deltaUpdate.
+    // Both paths execute the same push algorithm, so scores must match exactly.
+    var ippr = IncrementalPpr.init(std.testing.allocator);
+    defer ippr.deinit();
+    try ippr.residuals.put(1, 1.0);
+    try ippr.dirty_nodes.put(1, {});
+    try ippr.deltaUpdate(&g);
+
+    try std.testing.expectApproxEqAbs(full.get(1) orelse 0, ippr.getScore(1), 1e-3);
+    try std.testing.expectApproxEqAbs(full.get(2) orelse 0, ippr.getScore(2), 1e-3);
+    try std.testing.expectApproxEqAbs(full.get(3) orelse 0, ippr.getScore(3), 1e-3);
+}
+
+test "regression: edge addition - new dst scored, equal-weight neighbours get equal share" {
+    const ppr_mod = @import("ppr.zig");
+
+    // Part 1: fresh-start proportionality check.
+    // Graph: 1->2, 1->3 (equal weight). Seed r[1]=1.0.
+    // The push rule must distribute equally to both neighbours.
+    {
+        var g = makeTestGraph(std.testing.allocator);
+        defer g.deinit();
+        try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+        try g.addEdge(.{ .src = 1, .dst = 3, .kind = .calls });
+
+        var ippr = IncrementalPpr.init(std.testing.allocator);
+        defer ippr.deinit();
+        try ippr.residuals.put(1, 1.0);
+        try ippr.dirty_nodes.put(1, {});
+        try ippr.deltaUpdate(&g);
+
+        const s2 = ippr.getScore(2);
+        const s3 = ippr.getScore(3);
+        try std.testing.expect(s2 > 0);
+        try std.testing.expect(s3 > 0);
+        // Equal-weight edges → equal scores (push rule: W(u,v)/W_out(u) = 0.5 for both)
+        try std.testing.expectApproxEqAbs(s2, s3, 1e-4);
+    }
+
+    // Part 2: incremental update causes new dst to score.
+    // Node 2 keeps its accumulated history; node 3 starts from zero but must be scored.
+    {
+        var g = makeTestGraph(std.testing.allocator);
+        defer g.deinit();
+        try g.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+
+        var full0 = try ppr_mod.pprPush(&g, 1, DEFAULT_ALPHA, DEFAULT_EPSILON, std.testing.allocator);
+        defer full0.deinit();
+
+        var ippr = try IncrementalPpr.initFromFull(full0, std.testing.allocator);
+        defer ippr.deinit();
+
+        try g.addEdge(.{ .src = 1, .dst = 3, .kind = .calls });
+        try ippr.onEdgeAdded(1, 3, 1.0);
+        try ippr.deltaUpdate(&g);
+
+        try std.testing.expect(ippr.getScore(3) > 0);
+        try std.testing.expect(ippr.getScore(2) > 0);
+        try std.testing.expect(ippr.getScore(1) > 0);
+    }
+}
+
+test "regression: edge removal - removed dst score decreases, topology reflected" {
+    const ppr_mod = @import("ppr.zig");
+
+    // Initial graph: 1 -> 2, 1 -> 3 (symmetric)
+    var g_init = makeTestGraph(std.testing.allocator);
+    defer g_init.deinit();
+    try g_init.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+    try g_init.addEdge(.{ .src = 1, .dst = 3, .kind = .calls });
+
+    var full0 = try ppr_mod.pprPush(&g_init, 1, DEFAULT_ALPHA, DEFAULT_EPSILON, std.testing.allocator);
+    defer full0.deinit();
+
+    var ippr = try IncrementalPpr.initFromFull(full0, std.testing.allocator);
+    defer ippr.deinit();
+
+    const s3_before = ippr.getScore(3);
+
+    // Build updated graph without edge 1 -> 3
+    var g2 = makeTestGraph(std.testing.allocator);
+    defer g2.deinit();
+    try g2.addEdge(.{ .src = 1, .dst = 2, .kind = .calls });
+
+    // Notify incremental of removal and update against the new topology
+    try ippr.onEdgeRemoved(1, 3);
+    try ippr.deltaUpdate(&g2);
+
+    // dst's score must decrease (no longer receives flow from src)
+    const s3_after = ippr.getScore(3);
+    try std.testing.expect(s3_after < s3_before);
+
+    // src and the remaining neighbour must still score positively
+    try std.testing.expect(ippr.getScore(1) > 0);
+    try std.testing.expect(ippr.getScore(2) > 0);
+
+    // Fresh full PPR on the updated graph confirms node 3 is unreachable
+    var full1 = try ppr_mod.pprPush(&g2, 1, DEFAULT_ALPHA, DEFAULT_EPSILON, std.testing.allocator);
+    defer full1.deinit();
+    try std.testing.expectEqual(@as(?f32, null), full1.get(3));
+    try std.testing.expect((full1.get(2) orelse 0) > 0);
 }

--- a/src/graph/wal.zig
+++ b/src/graph/wal.zig
@@ -278,7 +278,7 @@ fn parseRecord(data: []const u8, start: usize, op_byte: u8) !ParseResult {
             const id = try readU32(data, &pos);
             const path = try readBytesView(data, &pos);
             if (pos >= data.len) return error.Truncated;
-            const language: Language = @enumFromInt(data[pos]);
+            const language: Language = std.meta.intToEnum(Language, data[pos]) catch return error.InvalidOp;
             pos += 1;
             const last_modified = try readI64(data, &pos);
             if (pos + 32 > data.len) return error.Truncated;
@@ -316,7 +316,7 @@ fn parseRecord(data: []const u8, start: usize, op_byte: u8) !ParseResult {
             const src = try readU64(data, &pos);
             const dst = try readU64(data, &pos);
             if (pos >= data.len) return error.Truncated;
-            const kind: EdgeKind = @enumFromInt(data[pos]);
+            const kind: EdgeKind = std.meta.intToEnum(EdgeKind, data[pos]) catch return error.InvalidOp;
             pos += 1;
             if (pos + 4 > data.len) return error.Truncated;
             const weight: f32 = @bitCast(data[pos..][0..4].*);
@@ -793,6 +793,50 @@ test "WAL single byte of garbage produces zero records" {
     var g = CodeGraph.init(std.testing.allocator);
     defer g.deinit();
     var result = try replay(&garbage, &g, std.testing.allocator);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), result.records_applied);
+}
+
+test "WAL invalid Language byte stops replay gracefully" {
+    var w = WalWriter.init(std.testing.allocator);
+    defer w.deinit();
+
+    try w.logAddFile(.{ .id = 1, .path = "", .language = .zig, .last_modified = 0, .hash = [_]u8{0} ** 32 });
+
+    var data = try std.testing.allocator.alloc(u8, w.data().len);
+    defer std.testing.allocator.free(data);
+    @memcpy(data, w.data());
+
+    // Record layout: [op:1][id:4][path_len:4][language:1][...]
+    // Language byte is at offset 9 (1 op + 4 id + 4 path_len, empty path)
+    data[9] = 0xFE; // invalid Language value (not 0-3 or 255)
+
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+    var result = try replay(data, &g, std.testing.allocator);
+    defer result.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), result.records_applied);
+}
+
+test "WAL invalid EdgeKind byte stops replay gracefully" {
+    var w = WalWriter.init(std.testing.allocator);
+    defer w.deinit();
+
+    try w.logAddEdge(.{ .src = 1, .dst = 2, .kind = .calls, .weight = 1.0 });
+
+    var data = try std.testing.allocator.alloc(u8, w.data().len);
+    defer std.testing.allocator.free(data);
+    @memcpy(data, w.data());
+
+    // Record layout: [op:1][src:8][dst:8][kind:1][...]
+    // EdgeKind byte is at offset 17 (1 op + 8 src + 8 dst)
+    data[17] = 0x05; // invalid EdgeKind value (valid range is 0-4)
+
+    var g = CodeGraph.init(std.testing.allocator);
+    defer g.deinit();
+    var result = try replay(data, &g, std.testing.allocator);
     defer result.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), result.records_applied);

--- a/src/graph/watcher.zig
+++ b/src/graph/watcher.zig
@@ -41,6 +41,7 @@ const WatchEntry = struct {
     exists: bool,
     last_change_ms: i64, // for debouncing
     pending: bool, // change detected but not yet reported (debounce)
+    is_new: bool, // true when pending event is a creation (not a modification)
 };
 
 // ── FileWatcher ─────────────────────────────────────────────────────────────
@@ -82,6 +83,7 @@ pub const FileWatcher = struct {
             .exists = stat != null,
             .last_change_ms = 0,
             .pending = false,
+            .is_new = false,
         });
     }
 
@@ -126,12 +128,14 @@ pub const FileWatcher = struct {
                     entry.last_size = s.size;
                     entry.last_change_ms = now_ms;
                     entry.pending = true;
+                    entry.is_new = true;
                 } else if (s.mtime != entry.last_modified_ns or s.size != entry.last_size) {
                     // File modified
                     entry.last_modified_ns = s.mtime;
                     entry.last_size = s.size;
                     entry.last_change_ms = now_ms;
                     entry.pending = true;
+                    entry.is_new = false;
                 }
             } else {
                 if (entry.exists) {
@@ -141,6 +145,7 @@ pub const FileWatcher = struct {
                     entry.last_size = 0;
                     entry.last_change_ms = now_ms;
                     entry.pending = true;
+                    entry.is_new = false;
                 }
             }
 
@@ -148,7 +153,7 @@ pub const FileWatcher = struct {
             if (entry.pending and (now_ms - entry.last_change_ms) >= self.debounce_ms) {
                 const kind: ChangeKind = if (!entry.exists)
                     .deleted
-                else if (entry.last_modified_ns == 0)
+                else if (entry.is_new)
                     .created
                 else
                     .modified;
@@ -159,6 +164,7 @@ pub const FileWatcher = struct {
                     .timestamp_ms = now_ms,
                 });
                 entry.pending = false;
+                entry.is_new = false;
             }
         }
 
@@ -399,4 +405,31 @@ test "debounce window prevents immediate reporting" {
     const events3 = try fw.pollAt(5300);
     defer std.testing.allocator.free(events3);
     try std.testing.expectEqual(@as(usize, 1), events3.len);
+}
+
+// Regression test for issue #224: newly created files must emit .created, not .modified
+test "new file emits ChangeKind.created" {
+    var fw = FileWatcher.init(std.testing.allocator);
+    defer fw.deinit();
+
+    const tmp = "_test_issue224_created.txt";
+
+    // Watch a path that does not exist yet
+    try fw.watch(tmp);
+
+    // Create the file
+    const f = try std.fs.cwd().createFile(tmp, .{});
+    f.close();
+    defer std.fs.cwd().deleteFile(tmp) catch {};
+
+    // First poll: detects creation, marks pending (debounce starts at t=1000)
+    const ev1 = try fw.pollAt(1000);
+    defer std.testing.allocator.free(ev1);
+    try std.testing.expectEqual(@as(usize, 0), ev1.len); // still within debounce
+
+    // Second poll: debounce elapsed — must emit exactly one .created event
+    const ev2 = try fw.pollAt(1400);
+    defer std.testing.allocator.free(ev2);
+    try std.testing.expectEqual(@as(usize, 1), ev2.len);
+    try std.testing.expectEqual(ChangeKind.created, ev2[0].kind);
 }


### PR DESCRIPTION
## Summary
4 Zig infrastructure bug fixes:

- **#226** (HIGH) — WAL replay: `@enumFromInt` on untrusted bytes → `std.meta.intToEnum` with graceful error on corrupt data
- **#225** (HIGH) — IPC server: stores actual `bound_path`, deletes correct socket on deinit (was deleting hardcoded constant)
- **#224** (MEDIUM) — Watcher: explicit `is_new` flag for `.created` vs `.modified` classification (mtime heuristic was always false)
- **#166** (HIGH) — PPR incremental: edge updates now un-absorb and re-push with correct `W(u,v)/W_out(u)` normalization

## Test plan
- [x] `zig build test` — all pass (+8 new tests)
- [x] `zig build -Doptimize=ReleaseFast` — clean
- [ ] CI checks

Closes #226, #225, #224, #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)