### PR TITLE
Revert accidental merge of #403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to CodeDB are documented here.
 
-## [Unreleased]
-
-### Changed
-- `create_issue` / `create_issues_batch` now enforce the issue evidence template implied by `CONTRIBUTING.md` plus the agent issue-discovery standard. `decompose_feature` now returns both the issue-discovery rules and a concrete issue body template for downstream issue creation.
-- `create_issue(parent_issue=...)` is now documented as a body annotation only: it appends `Parent issue: #N` for context and does not create a durable issue dependency. Use `link_issues` for explicit relationships.
 
 ## [0.0.24] — 2026-03-04
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,6 @@ Each agent gets the right model automatically:
 **Issues**
 `create_issue` · `update_issue` · `close_issue` · `get_issue` · `create_issues_batch` · `close_issues_batch` · `link_issues`
 
-Issue-filing note: `create_issue` and `create_issues_batch` now enforce the issue template implied by [`CONTRIBUTING.md`](CONTRIBUTING.md) and the agent issue-discovery standard. Issue bodies must include: one-sentence problem, exact repro, observed result, expected result, nearby passing checks, acceptance criteria, and non-goals.
-`create_issue(parent_issue=...)` is context-only: it appends `Parent issue: #N` to the body. Use `link_issues` for explicit dependency links.
-
 **Git**
 `create_branch` · `get_current_branch` · `commit_with_context` · `push_branch` · `recently_changed` · `git_history_for`
 

--- a/src/codex_appserver.zig
+++ b/src/codex_appserver.zig
@@ -10,18 +10,18 @@
 // Wire format: newline-delimited JSON, `"jsonrpc":"2.0"` header omitted.
 
 const std = @import("std");
-const mj = @import("mcp").json;
+const mj  = @import("mcp").json;
 
 // ── Startup: resolve zig tools directory once ─────────────────────────────────
 //
 // Walks the current process PATH to find zigrep.  Cached after the first
 // call so every subsequent runTurnPolicy call is allocation-free here.
 const ToolsDir = struct {
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    var len: usize = 0;
-    var found: bool = false;
-    var checked: bool = false;
-    var mu: std.Thread.Mutex = .{};
+    var buf:     [std.fs.max_path_bytes]u8 = undefined;
+    var len:     usize = 0;
+    var found:   bool  = false;
+    var checked: bool  = false;
+    var mu:      std.Thread.Mutex = .{};
 
     /// Returns the directory that contains zigrep, or null if not found.
     /// Thread-safe; resolves at most once.
@@ -31,17 +31,14 @@ const ToolsDir = struct {
         if (checked) return if (found) buf[0..len] else null;
         checked = true;
         const path_env = std.process.getEnvVarOwned(
-            std.heap.page_allocator,
-            "PATH",
+            std.heap.page_allocator, "PATH",
         ) catch return null;
         defer std.heap.page_allocator.free(path_env);
         var it = std.mem.splitScalar(u8, path_env, ':');
         while (it.next()) |dir| {
             var cbuf: [std.fs.max_path_bytes]u8 = undefined;
             const candidate = std.fmt.bufPrint(
-                &cbuf,
-                "{s}/zigrep",
-                .{dir},
+                &cbuf, "{s}/zigrep", .{dir},
             ) catch continue;
             std.fs.accessAbsolute(candidate, .{}) catch continue;
             const n = @min(dir.len, buf.len);
@@ -83,9 +80,9 @@ pub const SandboxPolicy = enum { read_only, writable };
 /// Run a single agent turn via `codex app-server`.
 /// Blocks until `turn/completed`. Accumulated agent reply is appended to `out`.
 pub fn runTurn(
-    alloc: std.mem.Allocator,
+    alloc:  std.mem.Allocator,
     prompt: []const u8,
-    out: *std.ArrayList(u8),
+    out:    *std.ArrayList(u8),
 ) void {
     runTurnPolicy(alloc, prompt, out, .read_only);
 }
@@ -93,9 +90,9 @@ pub fn runTurn(
 /// Run a single agent turn via `codex app-server` inside a login shell.
 /// Blocks until `turn/completed`. Accumulated agent reply is appended to `out`.
 pub fn runTurnPolicy(
-    alloc: std.mem.Allocator,
+    alloc:  std.mem.Allocator,
     prompt: []const u8,
-    out: *std.ArrayList(u8),
+    out:    *std.ArrayList(u8),
     policy: SandboxPolicy,
 ) void {
     const cwd = std.process.getCwdAlloc(alloc) catch {
@@ -109,13 +106,10 @@ pub fn runTurnPolicy(
     // is still forwarded as-is — HOME is present so codex finds its config.
     var env_map = std.process.getEnvMap(alloc) catch std.process.EnvMap.init(alloc);
     defer env_map.deinit();
-    stripNestedCodexEnv(&env_map);
     if (ToolsDir.get()) |tools_dir| {
         const old_path = env_map.get("PATH") orelse "/usr/local/bin:/usr/bin:/bin";
         const new_path = std.fmt.allocPrint(
-            alloc,
-            "{s}:{s}",
-            .{ tools_dir, old_path },
+            alloc, "{s}:{s}", .{ tools_dir, old_path },
         ) catch null;
         if (new_path) |np| {
             defer alloc.free(np);
@@ -128,10 +122,10 @@ pub fn runTurnPolicy(
     // ── Option 1: direct spawn ────────────────────────────────────────────
     // Spawn `codex app-server` directly.  Fast path — no shell overhead.
     var child = std.process.Child.init(&.{ "codex", "app-server" }, alloc);
-    child.stdin_behavior = .Pipe;
+    child.stdin_behavior  = .Pipe;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Close;
-    child.env_map = &env_map;
+    child.env_map         = &env_map;
 
     const spawned = child.spawn();
     if (spawned) |_| {
@@ -147,17 +141,17 @@ pub fn runTurnPolicy(
     // attach directly.
     const shell = std.process.getEnvVarOwned(alloc, "SHELL") catch
         alloc.dupe(u8, "/bin/zsh") catch {
-        appendErr(alloc, out, "could not spawn codex app-server — is codex on PATH?");
-        return;
-    };
+            appendErr(alloc, out, "could not spawn codex app-server — is codex on PATH?");
+            return;
+        };
     defer alloc.free(shell);
 
     const argv2 = [_][]const u8{ shell, "-lc", "exec codex app-server" };
     var child2 = std.process.Child.init(&argv2, alloc);
-    child2.stdin_behavior = .Pipe;
+    child2.stdin_behavior  = .Pipe;
     child2.stdout_behavior = .Pipe;
     child2.stderr_behavior = .Close;
-    child2.env_map = &env_map;
+    child2.env_map         = &env_map;
     child2.spawn() catch {
         appendErr(alloc, out, "could not spawn codex app-server via login shell — is codex installed?");
         return;
@@ -167,32 +161,23 @@ pub fn runTurnPolicy(
 
 /// Shared turn logic once a child process is spawned.
 fn runTurn_(
-    child: *std.process.Child,
-    alloc: std.mem.Allocator,
-    cwd: []const u8,
+    child:  *std.process.Child,
+    alloc:  std.mem.Allocator,
+    cwd:    []const u8,
     prompt: []const u8,
     policy: SandboxPolicy,
-    out: *std.ArrayList(u8),
+    out:    *std.ArrayList(u8),
 ) void {
     defer _ = child.wait() catch {};
     defer _ = child.kill() catch {};
 
-    const proc_in = child.stdin orelse {
-        appendErr(alloc, out, "no stdin pipe");
-        return;
-    };
-    const proc_out = child.stdout orelse {
-        appendErr(alloc, out, "no stdout pipe");
-        return;
-    };
+    const proc_in  = child.stdin  orelse { appendErr(alloc, out, "no stdin pipe");  return; };
+    const proc_out = child.stdout orelse { appendErr(alloc, out, "no stdout pipe"); return; };
 
     // ── 1. initialize ──────────────────────────────────────────────────────
     writeMsg(proc_in,
         \\{"method":"initialize","id":0,"params":{"clientInfo":{"name":"gitagent","title":"gitagent-mcp","version":"0.1.0"}}}
-    ) catch {
-        appendErr(alloc, out, "write initialize failed");
-        return;
-    };
+    ) catch { appendErr(alloc, out, "write initialize failed"); return; };
 
     if (!drainUntilId(alloc, proc_out, 0)) {
         appendErr(alloc, out, "no response to initialize from codex app-server");
@@ -202,10 +187,7 @@ fn runTurn_(
     // ── 2. initialized notification ────────────────────────────────────────
     writeMsg(proc_in,
         \\{"method":"initialized","params":{}}
-    ) catch {
-        appendErr(alloc, out, "write initialized failed");
-        return;
-    };
+    ) catch { appendErr(alloc, out, "write initialized failed"); return; };
 
     // ── 3. thread/start ────────────────────────────────────────────────────
     {
@@ -213,7 +195,7 @@ fn runTurn_(
         // approvalPolicy:"never" suppresses all approval prompts.
         const policy_json: []const u8 = switch (policy) {
             .read_only => "{\"type\":\"readOnly\"}",
-            .writable => "{\"type\":\"dangerFullAccess\"}",
+            .writable  => "{\"type\":\"dangerFullAccess\"}",
         };
         var msg: std.ArrayList(u8) = .empty;
         defer msg.deinit(alloc);
@@ -225,8 +207,7 @@ fn runTurn_(
         mj.writeEscaped(alloc, &msg, cwd);
         msg.appendSlice(alloc, "\"}}") catch return;
         writeMsgSlice(proc_in, msg.items) catch {
-            appendErr(alloc, out, "write thread/start failed");
-            return;
+            appendErr(alloc, out, "write thread/start failed"); return;
         };
     }
 
@@ -248,8 +229,7 @@ fn runTurn_(
         mj.writeEscaped(alloc, &msg, prompt);
         msg.appendSlice(alloc, "\"}]}}") catch return;
         writeMsgSlice(proc_in, msg.items) catch {
-            appendErr(alloc, out, "write turn/start failed");
-            return;
+            appendErr(alloc, out, "write turn/start failed"); return;
         };
     }
 
@@ -269,8 +249,7 @@ fn runTurn_(
         mj.writeEscaped(alloc, &msg, thread_id);
         msg.appendSlice(alloc, "\"}}") catch return;
         writeMsgSlice(proc_in, msg.items) catch {
-            appendErr(alloc, out, "write thread/compact/start failed");
-            return;
+            appendErr(alloc, out, "write thread/compact/start failed"); return;
         };
     }
 
@@ -291,25 +270,11 @@ fn runTurn_(
         mj.writeEscaped(alloc, &msg, prompt);
         msg.appendSlice(alloc, "\"}]}}") catch return;
         writeMsgSlice(proc_in, msg.items) catch {
-            appendErr(alloc, out, "write retry turn/start failed");
-            return;
+            appendErr(alloc, out, "write retry turn/start failed"); return;
         };
     }
 
     _ = streamTurn(alloc, proc_out, out);
-}
-
-fn stripNestedCodexEnv(env_map: *std.process.EnvMap) void {
-    // Nested Codex app-server calls launched from Codex Desktop inherit session-
-    // specific CODEX_* variables that can wedge child agent startup. Mirror the
-    // CLAUDECODE nested-session guard in agent_sdk.zig.
-    env_map.remove("CODEX_THREAD_ID");
-    env_map.remove("CODEX_INTERNAL_ORIGINATOR_OVERRIDE");
-    env_map.remove("CODEX_CI");
-    env_map.remove("CODEX_SANDBOX");
-    env_map.remove("CODEX_SANDBOX_NETWORK_DISABLED");
-    env_map.remove("CODEX_SHELL");
-    env_map.remove("__CFBundleIdentifier");
 }
 
 // ── Wire helpers ──────────────────────────────────────────────────────────────
@@ -328,36 +293,18 @@ fn readLineAlloc(alloc: std.mem.Allocator, file: std.fs.File) ?[]u8 {
     var buf: [1]u8 = undefined;
     var line: std.ArrayList(u8) = .empty;
     while (true) {
-        const n = file.read(&buf) catch {
-            line.deinit(alloc);
-            return null;
-        };
+        const n = file.read(&buf) catch { line.deinit(alloc); return null; };
         if (n == 0) {
-            if (line.items.len == 0) {
-                line.deinit(alloc);
-                return null;
-            }
-            const owned = line.toOwnedSlice(alloc) catch {
-                line.deinit(alloc);
-                return null;
-            };
+            if (line.items.len == 0) { line.deinit(alloc); return null; }
+            const owned = line.toOwnedSlice(alloc) catch { line.deinit(alloc); return null; };
             return owned;
         }
         if (buf[0] == '\n') {
-            const owned = line.toOwnedSlice(alloc) catch {
-                line.deinit(alloc);
-                return null;
-            };
+            const owned = line.toOwnedSlice(alloc) catch { line.deinit(alloc); return null; };
             return owned;
         }
-        line.append(alloc, buf[0]) catch {
-            line.deinit(alloc);
-            return null;
-        };
-        if (line.items.len > 4 * 1024 * 1024) {
-            line.deinit(alloc);
-            return null;
-        }
+        line.append(alloc, buf[0]) catch { line.deinit(alloc); return null; };
+        if (line.items.len > 4 * 1024 * 1024) { line.deinit(alloc); return null; }
     }
 }
 
@@ -371,10 +318,7 @@ fn drainUntilId(alloc: std.mem.Allocator, rd: anytype, target_id: i64) bool {
         defer p.deinit();
         if (p.value != .object) continue;
         const id_v = p.value.object.get("id") orelse continue;
-        const id: i64 = switch (id_v) {
-            .integer => |n| n,
-            else => continue,
-        };
+        const id: i64 = switch (id_v) { .integer => |n| n, else => continue };
         if (id == target_id) return true;
     }
 }
@@ -388,16 +332,13 @@ fn readThreadId(alloc: std.mem.Allocator, rd: anytype) ?[]u8 {
         if (p.value != .object) continue;
         const obj = &p.value.object;
         const id_v = obj.get("id") orelse continue;
-        const id: i64 = switch (id_v) {
-            .integer => |n| n,
-            else => continue,
-        };
+        const id: i64 = switch (id_v) { .integer => |n| n, else => continue };
         if (id != 1) continue;
-        const result = obj.get("result") orelse continue;
+        const result = obj.get("result")          orelse continue;
         if (result != .object) continue;
         const thread = result.object.get("thread") orelse continue;
         if (thread != .object) continue;
-        const tid = thread.object.get("id") orelse continue;
+        const tid    = thread.object.get("id")     orelse continue;
         if (tid != .string) continue;
         return alloc.dupe(u8, tid.string) catch null;
     }
@@ -429,9 +370,9 @@ fn streamTurn(alloc: std.mem.Allocator, rd: anytype, out: *std.ArrayList(u8)) bo
         if (std.mem.eql(u8, method, "turn/completed")) {
             const params = obj.get("params") orelse return false;
             if (params != .object) return false;
-            const turn = params.object.get("turn") orelse return false;
+            const turn   = params.object.get("turn")   orelse return false;
             if (turn != .object) return false;
-            const status = turn.object.get("status") orelse return false;
+            const status = turn.object.get("status")   orelse return false;
             if (status == .string and std.mem.eql(u8, status.string, "failed")) {
                 if (turn.object.get("error")) |err_v| {
                     if (err_v == .object) {
@@ -488,7 +429,7 @@ test "appserver: readLineAlloc reads up to newline, strips newline" {
     const reader = std.fs.File{ .handle = fds[0] };
 
     try writer.writeAll("hello world\n");
-    writer.close();
+writer.close();
 
     const line = readLineAlloc(alloc, reader) orelse return error.TestExpectedLine;
     defer alloc.free(line);
@@ -516,7 +457,7 @@ test "appserver: readLineAlloc returns partial content on EOF without newline" {
     const reader = std.fs.File{ .handle = fds[0] };
 
     try writer.writeAll("no-newline");
-    writer.close();
+writer.close();
 
     const line = readLineAlloc(alloc, reader) orelse return error.TestExpectedLine;
     defer alloc.free(line);
@@ -535,7 +476,7 @@ test "appserver: drainUntilId finds target id after skipping earlier ids" {
     try writer.writeAll("{\"id\":0,\"result\":{}}\n");
     try writer.writeAll("{\"id\":1,\"result\":{}}\n");
     try writer.writeAll("{\"id\":5,\"result\":{}}\n");
-    writer.close();
+writer.close();
 
     const found = drainUntilId(alloc, reader, 5);
     try std.testing.expect(found);
@@ -551,7 +492,7 @@ test "appserver: drainUntilId returns false on EOF before target id" {
     const reader = std.fs.File{ .handle = fds[0] };
 
     try writer.writeAll("{\"id\":1,\"result\":{}}\n");
-    writer.close();
+writer.close();
 
     const found = drainUntilId(alloc, reader, 99);
     try std.testing.expect(!found);
@@ -569,7 +510,7 @@ test "appserver: readThreadId extracts id from thread/start response" {
     // id=0 should be skipped (readThreadId looks for id=1)
     try writer.writeAll("{\"id\":0,\"result\":{}}\n");
     try writer.writeAll("{\"id\":1,\"result\":{\"thread\":{\"id\":\"thread-xyz\"}}}\n");
-    writer.close();
+writer.close();
 
     const tid = readThreadId(alloc, reader) orelse return error.TestExpectedThreadId;
     defer alloc.free(tid);
@@ -587,7 +528,7 @@ test "appserver: readThreadId returns null when thread.id is missing" {
 
     // id=1 response but no thread.id field
     try writer.writeAll("{\"id\":1,\"result\":{\"other\":\"data\"}}\n");
-    writer.close();
+writer.close();
 
     const tid = readThreadId(alloc, reader);
     try std.testing.expectEqual(@as(?[]u8, null), tid);
@@ -605,7 +546,7 @@ test "appserver: streamTurn accumulates agentMessage deltas and stops at turn/co
     try writer.writeAll("{\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"Hello, \"}}\n");
     try writer.writeAll("{\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"world!\"}}\n");
     try writer.writeAll("{\"method\":\"turn/completed\",\"params\":{\"turn\":{\"status\":\"completed\"}}}\n");
-    writer.close();
+writer.close();
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(alloc);
@@ -624,9 +565,9 @@ test "appserver: streamTurn appends error message on failed turn" {
 
     try writer.writeAll(
         \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"agent crashed"}}}}
-    ++ "\n",
+        ++ "\n",
     );
-    writer.close();
+writer.close();
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(alloc);
@@ -644,7 +585,7 @@ test "appserver: streamTurn returns true on ContextWindowExceeded via codexError
 
     try writer.writeAll(
         \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"context full","codexErrorInfo":"ContextWindowExceeded"}}}}
-    ++ "\n",
+        ++ "\n",
     );
     writer.close();
 
@@ -666,7 +607,7 @@ test "appserver: streamTurn returns true on context window message substring fal
 
     try writer.writeAll(
         \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"Codex ran out of room in the model's context window. Start a new thread."}}}}
-    ++ "\n",
+        ++ "\n",
     );
     writer.close();
 
@@ -687,7 +628,7 @@ test "appserver: streamTurn returns false on non-context-window failure" {
 
     try writer.writeAll(
         \\{"method":"turn/completed","params":{"turn":{"status":"failed","error":{"message":"internal server error","codexErrorInfo":"InternalServerError"}}}}
-    ++ "\n",
+        ++ "\n",
     );
     writer.close();
 
@@ -708,7 +649,7 @@ test "appserver: streamTurn returns false on successful turn with no output" {
 
     try writer.writeAll(
         \\{"method":"turn/completed","params":{"turn":{"status":"completed"}}}
-    ++ "\n",
+        ++ "\n",
     );
     writer.close();
 
@@ -732,7 +673,7 @@ test "appserver: streamTurn skips unknown notifications before turn/completed" {
     try writer.writeAll("{\"method\":\"item/agentMessage/delta\",\"params\":{\"delta\":\"result\"}}\n");
     try writer.writeAll(
         \\{"method":"turn/completed","params":{"turn":{"status":"completed"}}}
-    ++ "\n",
+        ++ "\n",
     );
     writer.close();
 

--- a/src/runtime/prompts.zig
+++ b/src/runtime/prompts.zig
@@ -18,20 +18,6 @@ const roles = @import("roles.zig");
 const AgentMode = types.AgentMode;
 const ToolTier = cascade.ToolTier;
 
-const ISSUE_FILING_RULES =
-    \\ISSUE FILING:
-    \\  - Do not file a new issue from casual code inspection alone when runtime proof is practical.
-    \\  - Before proposing or filing an agent-discovered issue, prefer evidence-backed discovery:
-    \\    run the code path, re-check stale xfail/xpass/skip tests, compare docs vs runnable behavior,
-    \\    compare neighboring execution paths, and use differential or edge-case testing where relevant.
-    \\  - Only file issues that are narrow, reproducible, and verified on the current codebase state.
-    \\  - A strong issue must include: one concrete repro, observed result, expected result,
-    \\    one or two nearby passing checks, narrow acceptance criteria, and explicit non-goals.
-    \\  - If you cannot reduce the finding to one concrete problem with one reproducible path,
-    \\    gather better evidence instead of filing the issue yet.
-    \\
-;
-
 // ── Agency Preamble ─────────────────────────────────────────────────────────
 // Derived from our internal analysis of production agent behaviors observed
 // across multiple coding agent platforms. Patterns validated against public
@@ -54,8 +40,6 @@ const AGENCY_PREAMBLE =
     \\  - If a task is complex, break it into sub-steps and work through them systematically.
     \\  - Cite file:line for every finding and every change you make.
     \\  - When multiple independent operations are needed, batch them in parallel.
-    \\
-    \\{s}
     \\
     \\CODE QUALITY:
     \\  - Read before editing. Always understand existing code before modifying it.
@@ -152,16 +136,16 @@ const MINIMAL_TOOLS_PREAMBLE =
 fn modeGuidance(mode: AgentMode) []const u8 {
     return switch (mode) {
         .smart => "MODE: balanced — thorough but concise. Search broadly first, then narrow. " ++
-            "Use parallel searches when exploring multiple angles. " ++
-            "Batch independent reads and edits together for speed.",
-        .rush => "MODE: fast — give the quickest useful answer. Minimize search depth. " ++
-            "Keep responses under 3 lines. One search pass, then act.",
-        .deep => "MODE: thorough — take your time. Explore all angles exhaustively. " ++
-            "Read full files, trace call chains, check callers and callees. " ++
-            "Run multiple search passes with different wording. " ++
-            "Explain your reasoning. Plan before acting.",
-        .free => "MODE: budget — minimal resource usage. Short answers, no unnecessary " ++
-            "exploration. One search, one answer. Fewest tokens possible.",
+                  "Use parallel searches when exploring multiple angles. " ++
+                  "Batch independent reads and edits together for speed.",
+        .rush  => "MODE: fast — give the quickest useful answer. Minimize search depth. " ++
+                  "Keep responses under 3 lines. One search pass, then act.",
+        .deep  => "MODE: thorough — take your time. Explore all angles exhaustively. " ++
+                  "Read full files, trace call chains, check callers and callees. " ++
+                  "Run multiple search passes with different wording. " ++
+                  "Explain your reasoning. Plan before acting.",
+        .free  => "MODE: budget — minimal resource usage. Short answers, no unnecessary " ++
+                  "exploration. One search, one answer. Fewest tokens possible.",
     };
 }
 
@@ -169,8 +153,8 @@ fn modeGuidance(mode: AgentMode) []const u8 {
 pub fn toolPreamble(tier: ToolTier) []const u8 {
     return switch (tier) {
         .zig_tools => ZIG_TOOLS_PREAMBLE,
-        .standard => STANDARD_TOOLS_PREAMBLE,
-        .minimal => MINIMAL_TOOLS_PREAMBLE,
+        .standard  => STANDARD_TOOLS_PREAMBLE,
+        .minimal   => MINIMAL_TOOLS_PREAMBLE,
     };
 }
 
@@ -208,15 +192,11 @@ pub fn assemble(
 
     const mode_line = modeGuidance(mode);
     const tool_pre = toolPreamble(tier);
-    const agency_pre = std.fmt.allocPrint(alloc, AGENCY_PREAMBLE, .{ISSUE_FILING_RULES}) catch
-        return alloc.dupe(u8, tool_pre) catch ASSEMBLE_OOM_SENTINEL;
-    defer alloc.free(agency_pre);
 
     // Format: [agency]\n[role]\n[mode]\n\n[tools]\nTask:\n
-    return std.fmt.allocPrint(
-        alloc,
+    return std.fmt.allocPrint(alloc,
         "{s}\n{s}\n{s}\n\n{s}\nTask:\n",
-        .{ agency_pre, role_prompt, mode_line, tool_pre },
+        .{ AGENCY_PREAMBLE, role_prompt, mode_line, tool_pre },
     ) catch alloc.dupe(u8, tool_pre) catch ASSEMBLE_OOM_SENTINEL;
 }
 
@@ -241,7 +221,6 @@ test "prompts: assemble includes agency, role, mode, and tools" {
     // Agency preamble
     try std.testing.expect(std.mem.indexOf(u8, result, "coding agent") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "CODE QUALITY") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result, "ISSUE FILING") != null);
     // Role prompt
     try std.testing.expect(std.mem.indexOf(u8, result, "code finder") != null);
     // Mode guidance

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -21,48 +21,6 @@ const graph_query = @import("graph/query.zig");
 const graph_mod = @import("graph/graph.zig");
 const graph_store = @import("graph/storage.zig");
 
-const ISSUE_DISCOVERY_STANDARD =
-    "For agent-discovered bugs or regressions, do not file from casual inspection alone when runtime proof is practical. " ++
-    "Prefer running the code path, re-checking stale xfail/xpass/skip tests, comparing docs versus runnable behavior, " ++
-    "comparing neighboring execution paths, and using differential or edge-case testing where relevant. " ++
-    "Only file narrow, reproducible issues verified on the current codebase. " ++
-    "Include one concrete repro, observed result, expected result, one or two nearby passing checks, " ++
-    "narrow acceptance criteria, and explicit non-goals.";
-
-const DECOMPOSE_FEATURE_INSTRUCTIONS =
-    "Use create_issues_batch to create the issues. status:backlog is auto-applied by create_issue when available. " ++
-    "For ordering, add one of priority:p0, priority:p1, priority:p2, or priority:p3 as needed. " ++
-    "Return an array of objects with title, body, and labels fields. " ++
-    "This tool is for feature planning. For newly discovered bugs or regressions, do not create issues from casual inspection alone; " ++
-    "first gather runtime-verifiable evidence. Every agent-discovered issue should include: Exact repro, Observed result, Expected result, " ++
-    "Nearby passing checks, Acceptance criteria, and Non-goals. If you cannot reduce the finding to one concrete problem with one reproducible path, gather better evidence before filing.";
-
-const ISSUE_TEMPLATE =
-    "## One-sentence problem\n" ++
-    "<one concrete problem>\n\n" ++
-    "## Exact repro\n" ++
-    "<one concrete command, test, API call, UI flow, or script>\n\n" ++
-    "## Observed result\n" ++
-    "<actual observed failure, output, or mismatch>\n\n" ++
-    "## Expected result\n" ++
-    "<what should happen instead>\n\n" ++
-    "## Nearby passing checks\n" ++
-    "- <one or two nearby passing checks>\n\n" ++
-    "## Acceptance criteria\n" ++
-    "- <narrow, testable fix target>\n\n" ++
-    "## Non-goals\n" ++
-    "- <what this issue is not asking for>\n";
-
-const REQUIRED_ISSUE_SECTIONS = [_][]const u8{
-    "## One-sentence problem",
-    "## Exact repro",
-    "## Observed result",
-    "## Expected result",
-    "## Nearby passing checks",
-    "## Acceptance criteria",
-    "## Non-goals",
-};
-
 // ── Dynamic repo slug ─────────────────────────────────────────────────────────
 // Updated from CWD on startup (notifications/initialized) and on every set_repo.
 // MCP dispatch is single-threaded; mutex is belt-and-suspenders for drainer threads.
@@ -86,53 +44,6 @@ fn repoOrErr(alloc: std.mem.Allocator, out: *std.ArrayList(u8)) ?[]const u8 {
         return null;
     }
     return repo;
-}
-
-fn validateIssueDraft(alloc: std.mem.Allocator, title: []const u8, body: []const u8) ?[]u8 {
-    if (std.mem.trim(u8, title, " \t\n\r").len == 0) {
-        return alloc.dupe(u8, "issue title must not be empty") catch null;
-    }
-    if (std.mem.trim(u8, body, " \t\n\r").len == 0) {
-        return std.fmt.allocPrint(
-            alloc,
-            "issue body is required and must follow the CONTRIBUTING.md / AGENT.md issue template. Missing body.\n\nRequired template:\n{s}",
-            .{ISSUE_TEMPLATE},
-        ) catch null;
-    }
-
-    var missing: std.ArrayList([]const u8) = .empty;
-    defer missing.deinit(alloc);
-    for (REQUIRED_ISSUE_SECTIONS) |section| {
-        if (std.mem.indexOf(u8, body, section) == null) {
-            missing.append(alloc, section) catch {};
-        }
-    }
-
-    if (missing.items.len == 0) return null;
-
-    var joined: std.ArrayList(u8) = .empty;
-    defer joined.deinit(alloc);
-    for (missing.items, 0..) |section, i| {
-        if (i > 0) joined.appendSlice(alloc, ", ") catch {};
-        joined.appendSlice(alloc, section) catch {};
-    }
-
-    return std.fmt.allocPrint(
-        alloc,
-        "issue body does not satisfy CONTRIBUTING.md / AGENT.md issue requirements. Missing required section(s): {s}.\n\nRequired template:\n{s}",
-        .{ joined.items, ISSUE_TEMPLATE },
-    ) catch null;
-}
-
-fn buildIssueBody(
-    alloc: std.mem.Allocator,
-    raw_body: []const u8,
-    parent_issue: ?i64,
-) ?[]u8 {
-    if (parent_issue) |num| {
-        return std.fmt.allocPrint(alloc, "{s}\n\nParent issue: #{d}", .{ raw_body, num }) catch null;
-    }
-    return alloc.dupe(u8, raw_body) catch null;
 }
 
 fn setCurrentRepo(slug: []const u8) void {
@@ -277,12 +188,12 @@ pub const Tool = enum {
 
 pub const tools_list =
     \\{"tools":[
-    \\{"name":"decompose_feature","description":"Break a natural language feature description into ordered GitHub Issue drafts. Returns a JSON schema and available labels/milestones for the caller to populate. Call this before any new feature work; it is for feature planning, not speculative bug filing.","inputSchema":{"type":"object","properties":{"feature_description":{"type":"string","description":"Plain English description of the feature to build"}},"required":["feature_description"]}},
+    \\{"name":"decompose_feature","description":"Break a natural language feature description into ordered GitHub Issue drafts. Returns a JSON schema and available labels/milestones for the caller to populate. Call this before any new feature work.","inputSchema":{"type":"object","properties":{"feature_description":{"type":"string","description":"Plain English description of the feature to build"}},"required":["feature_description"]}},
     \\{"name":"get_project_state","description":"Return all open issues grouped by status label, all open branches, and all open PRs. Use this to understand current project state before picking up work.","inputSchema":{"type":"object","properties":{},"required":[]}},
     \\{"name":"get_next_task","description":"Return the single highest-priority unblocked issue that has no open branch. Use this to decide what to work on next.","inputSchema":{"type":"object","properties":{},"required":[]}},
     \\{"name":"prioritize_issues","description":"Apply priority labels (priority:p0–p3) to a set of issues based on their dependency order. Sinks (no dependents) get p0; independent issues get p2.","inputSchema":{"type":"object","properties":{"issue_numbers":{"type":"array","items":{"type":"integer"},"description":"Issue numbers to prioritize"}},"required":["issue_numbers"]}},
-    \\{"name":"create_issue","description":"Create a single GitHub issue with title, body, labels, and optional milestone. Automatically applies status:backlog if no status label is provided. This tool enforces the issue requirements from CONTRIBUTING.md and AGENT.md: the body must include One-sentence problem, Exact repro, Observed result, Expected result, Nearby passing checks, Acceptance criteria, and Non-goals. If parent_issue is provided, create_issue only appends `Parent issue: #N` to the issue body for context; use link_issues for explicit dependency relationships.","inputSchema":{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string","description":"Required. Must follow the CONTRIBUTING.md / AGENT.md issue template with the required evidence sections."},"labels":{"type":"array","items":{"type":"string"}},"milestone":{"type":"string"},"parent_issue":{"type":"integer","description":"Optional parent issue number to append as `Parent issue: #N` in the issue body for context only. This does not create a durable GitHub subtask/dependency relationship; use link_issues for explicit links."}},"required":["title","body"]}},
-    \\{"name":"create_issues_batch","description":"Create multiple GitHub issues in one call. Issues are fired concurrently in batches of 5 with a 200ms collection window. Use this after decompose_feature to create all issues at once. Each issue body must satisfy the same CONTRIBUTING.md / AGENT.md evidence template enforced by create_issue.","inputSchema":{"type":"object","properties":{"issues":{"type":"array","items":{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string","description":"Required. Must follow the CONTRIBUTING.md / AGENT.md issue template with the required evidence sections."},"labels":{"type":"array","items":{"type":"string"}},"milestone":{"type":"string"}},"required":["title","body"]}}},"required":["issues"]}},
+    \\{"name":"create_issue","description":"Create a single GitHub issue with title, body, labels, and optional milestone. Automatically applies status:backlog if no status label is provided.","inputSchema":{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string"},"labels":{"type":"array","items":{"type":"string"}},"milestone":{"type":"string"},"parent_issue":{"type":"integer","description":"Issue number this is a subtask of"}},"required":["title"]}},
+    \\{"name":"create_issues_batch","description":"Create multiple GitHub issues in one call. Issues are fired concurrently in batches of 5 with a 200ms collection window. Use this after decompose_feature to create all issues at once.","inputSchema":{"type":"object","properties":{"issues":{"type":"array","items":{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string"},"labels":{"type":"array","items":{"type":"string"}},"milestone":{"type":"string"}},"required":["title"]}}},"required":["issues"]}},
     \\{"name":"update_issue","description":"Update an existing issue's title, body, or labels.","inputSchema":{"type":"object","properties":{"issue_number":{"type":"integer"},"title":{"type":"string"},"body":{"type":"string"},"add_labels":{"type":"array","items":{"type":"string"}},"remove_labels":{"type":"array","items":{"type":"string"}}},"required":["issue_number"]}},
     \\{"name":"close_issues_batch","description":"Close multiple issues at once. Each issue is marked status:done. Use this instead of calling close_issue N times.","inputSchema":{"type":"object","properties":{"issue_numbers":{"type":"array","items":{"type":"integer"},"description":"Issue numbers to close"},"pr_number":{"type":"integer","description":"PR number that resolves all these issues (optional)"}},"required":["issue_numbers"]}},
     \\{"name":"close_issue","description":"Close an issue and mark it status:done. Optionally reference the PR that resolved it.","inputSchema":{"type":"object","properties":{"issue_number":{"type":"integer"},"pr_number":{"type":"integer","description":"PR number that resolves this issue"}},"required":["issue_number"]}},
@@ -308,13 +219,13 @@ pub const tools_list =
     \\{"name":"find_dependents","description":"Find all symbols that transitively depend on the given symbol, ranked by Personalized PageRank score. Use this to understand the full blast radius of changing a symbol. Requires a CodeGraph DB file at .codegraph/graph.bin.","inputSchema":{"type":"object","properties":{"symbol_id":{"type":"integer","description":"Symbol ID to find dependents of"},"max_results":{"type":"integer","description":"Maximum number of results to return (default 10)"}},"required":["symbol_id"]}},
     \\{"name":"set_repo","description":"Switch the active repository path. All subsequent tool calls will operate against this repo. Invalidates the session cache.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to the git repository root"}},"required":["path"]}},
     \\{"name":"run_reviewer","description":"Invoke the Codex reviewer subagent on the current branch. Checks errdefer gaps, RwLock ordering, Zig 0.15.x API misuse, and missing test coverage. Returns the agent's full findings.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"Override the default review prompt"},"timeout_seconds":{"type":"integer","description":"Maximum time for agent execution (default 300, max 600)"}},"required":[]}},
-    \\{"name":"run_explorer","description":"Invoke the Codex explorer subagent to trace execution paths through the codebase. Read-only — maps affected code paths and gathers evidence without proposing fixes.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"What to explore, e.g. 'trace how get_next_task flows through gh.zig'"},"timeout_seconds":{"type":"integer","description":"Maximum time for agent execution (default 300, max 600)"}},"required":["prompt"]}},
+    \\{"name":"run_explorer","description":"Invoke the Codex explorer subagent to trace execution paths through the codebase. Read-only — maps affected code paths and gathers evidence without proposing fixes.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"What to explore, e.g. 'trace how get_next_task flows through gh.zig'"}},"required":["prompt"]}},
     \\{"name":"run_zig_infra","description":"Invoke the Codex zig_infra subagent to review build.zig module graph, named @import wiring, and test step coverage.","inputSchema":{"type":"object","properties":{"prompt":{"type":"string","description":"Override the default build wiring check prompt"}},"required":[]}},
     \\{\"name\":\"run_swarm\",\"description\":\"Spawn a self-organizing swarm of parallel sub-agents to tackle a task. Provider-agnostic: resolves the best backend (Claude/Codex) based on the model/mode you specify. An orchestrator decomposes the task into sub-tasks, up to max_agents run concurrently via Zig threads, and a synthesis agent combines their outputs. Set writable=true to allow agents to edit files (for bug fixes, refactors). Best for broad research, multi-file analysis, multi-angle reviews, or parallel bug fixing.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"prompt\":{\"type\":\"string\",\"description\":\"The high-level task for the swarm to solve\"},\"title\":{\"type\":\"string\",\"description\":\"Short human-readable label shown during execution\"},\"max_agents\":{\"type\":\"integer\",\"description\":\"Maximum parallel sub-agents (default 5, hard cap 100)\"},\"writable\":{\"type\":\"boolean\",\"description\":\"Allow agents to edit files and run shell commands (default false = read-only analysis)\"},\"model\":{\"type\":\"string\",\"description\":\"Model alias or full ID for all swarm agents (default: auto-resolved per role). Use \\\"opus\\\" for hardest tasks, \\\"haiku\\\" for fast/cheap parallel work.\"},\"mode\":{\"type\":\"string\",\"enum\":[\"smart\",\"rush\",\"deep\",\"free\"],\"description\":\"Agent mode applied to workers and synthesis agent (default: smart). Orchestrator uses rush unless overridden.\"},\"telemetry_out\":{\"type\":\"string\",\"description\":\"Optional file path to write telemetry JSON (cost, tokens, wall time, parallelism)\"}},\"required\":[\"prompt\"]}},
     \\{\"name\":\"run_agents\",\"description\":\"Run multiple agents in parallel within a single tool call. Each element of the agents array is a run_agent spec (same fields as run_agent). All agents execute concurrently via Zig threads; results are collected and returned as a JSON array once every agent completes. Use this instead of multiple sequential run_agent calls when the tasks are independent.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"agents\":{\"type\":\"array\",\"description\":\"Array of agent specs to run in parallel\",\"items\":{\"type\":\"object\",\"properties\":{\"prompt\":{\"type\":\"string\",\"description\":\"The task or question for this agent\"},\"model\":{\"type\":\"string\",\"description\":\"Model alias or full ID (default: auto-resolved)\"},\"role\":{\"type\":\"string\",\"description\":\"Agent role: finder, reviewer, fixer, explorer, architect, orchestrator, synthesizer, monitor\"},\"mode\":{\"type\":\"string\",\"enum\":[\"smart\",\"rush\",\"deep\",\"free\"]},\"writable\":{\"type\":\"boolean\"},\"allowed_tools\":{\"type\":\"string\"},\"permission_mode\":{\"type\":\"string\",\"enum\":[\"default\",\"acceptEdits\",\"bypassPermissions\"]},\"cwd\":{\"type\":\"string\"}},\"required\":[\"prompt\"]}}},\"required\":[\"agents\"]}},
     \\{\"name\":\"review_fix_loop\",\"description\":\"Iterative review-fix-review loop. Runs a read-only reviewer to find issues, then a writable agent to fix them, then re-reviews. Repeats until the reviewer reports no remaining issues or max_iterations is reached. Returns a JSON object with iteration history and convergence status.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"prompt\":{\"type\":\"string\",\"description\":\"Override the default review criteria\"},\"max_iterations\":{\"type\":\"integer\",\"description\":\"Maximum review-fix cycles (default 3, max 5)\"}},\"required\":[]}},
     \\{\"name\":\"run_agent\",\"description\":\"Run a single agent turn. Provider-agnostic: resolves the best backend (Claude/Codex) based on mode, role, and available providers. The primitive layer — use run_task for smart multi-step execution.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"prompt\":{\"type\":\"string\",\"description\":\"The task or question for the agent\"},\"model\":{\"type\":\"string\",\"description\":\"Model alias or full ID (default: claude-sonnet-4-6). Use \\\"opus\\\" for hardest tasks, \\\"haiku\\\" for fast/cheap.\"},\"role\":{\"type\":\"string\",\"description\":\"Agent role: finder, reviewer, fixer, explorer, architect, orchestrator, synthesizer, monitor\"},\"mode\":{\"type\":\"string\",\"enum\":[\"smart\",\"rush\",\"deep\",\"free\"],\"description\":\"Agent mode: smart (Sonnet), rush (Haiku), deep (Opus), free (Haiku)\"},\"allowed_tools\":{\"type\":\"string\",\"description\":\"Comma-separated tool allowlist, e.g. \\\"Bash,Read,Edit\\\". Omit to allow all tools.\"},\"permission_mode\":{\"type\":\"string\",\"enum\":[\"default\",\"acceptEdits\",\"bypassPermissions\"],\"description\":\"Permission mode for file and shell operations\"},\"writable\":{\"type\":\"boolean\",\"description\":\"Allow file writes (maps to bypassPermissions when permission_mode is unset)\"},\"cwd\":{\"type\":\"string\",\"description\":\"Working directory override (default: current repo path)\"}},\"required\":[\"prompt\"]}},
-    \\{\"name\":\"run_task\",\"description\":\"Smart executor: analyzes a task, picks the right strategy and agents, runs them with appropriate roles and models. Use this instead of run_agent for multi-step tasks. Supports chain presets (finder_fixer, reviewer_fixer, explore_report, architect_build) or auto-selection.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"task\":{\"type\":\"string\",\"description\":\"Task description — what needs to be done\"},\"preset\":{\"type\":\"string\",\"enum\":[\"finder_fixer\",\"reviewer_fixer\",\"explore_report\",\"architect_build\",\"custom\"],\"description\":\"Chain preset (default: auto-select based on task)\"},\"mode\":{\"type\":\"string\",\"enum\":[\"smart\",\"rush\",\"deep\",\"free\"],\"description\":\"Agent mode for all agents in the chain\"},\"max_agents\":{\"type\":\"integer\",\"description\":\"Max agents to spawn (default: preset-determined)\"},\"writable\":{\"type\":\"boolean\",\"description\":\"Override write access (default: role-determined)\"},\"permission_mode\":{\"type\":\"string\",\"enum\":[\"default\",\"acceptEdits\",\"bypassPermissions\"],\"description\":\"Permission mode for file and shell operations\"},\"timeout_seconds\":{\"type\":\"integer\",\"description\":\"Maximum total time for the full chain (default 300, max 600)\"}},\"required\":[\"task\"]}}
+    \\{\"name\":\"run_task\",\"description\":\"Smart executor: analyzes a task, picks the right strategy and agents, runs them with appropriate roles and models. Use this instead of run_agent for multi-step tasks. Supports chain presets (finder_fixer, reviewer_fixer, explore_report, architect_build) or auto-selection.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"task\":{\"type\":\"string\",\"description\":\"Task description — what needs to be done\"},\"preset\":{\"type\":\"string\",\"enum\":[\"finder_fixer\",\"reviewer_fixer\",\"explore_report\",\"architect_build\",\"custom\"],\"description\":\"Chain preset (default: auto-select based on task)\"},\"mode\":{\"type\":\"string\",\"enum\":[\"smart\",\"rush\",\"deep\",\"free\"],\"description\":\"Agent mode for all agents in the chain\"},\"max_agents\":{\"type\":\"integer\",\"description\":\"Max agents to spawn (default: preset-determined)\"},\"writable\":{\"type\":\"boolean\",\"description\":\"Override write access (default: role-determined)\"},\"permission_mode\":{\"type\":\"string\",\"enum\":[\"default\",\"acceptEdits\",\"bypassPermissions\"],\"description\":\"Permission mode for file and shell operations\"}},\"required\":[\"task\"]}}
     \\]}
 ;
 
@@ -420,13 +331,9 @@ fn handleDecomposeFeature(
     } else {
         out.appendSlice(alloc, "[]") catch {};
     }
-    out.appendSlice(alloc, ",\"instructions\":\"") catch return;
-    mj.writeEscaped(alloc, out, DECOMPOSE_FEATURE_INSTRUCTIONS);
-    out.appendSlice(alloc, "\",\"issue_discovery_standard\":\"") catch return;
-    mj.writeEscaped(alloc, out, ISSUE_DISCOVERY_STANDARD);
-    out.appendSlice(alloc, "\",\"issue_template\":\"") catch return;
-    mj.writeEscaped(alloc, out, ISSUE_TEMPLATE);
-    out.appendSlice(alloc, "\"}") catch {};
+    out.appendSlice(alloc,
+        \\,"instructions":"Use create_issues_batch to create the issues. status:backlog is auto-applied by create_issue when available. For ordering, add one of priority:p0, priority:p1, priority:p2, or priority:p3 as needed. Return an array of objects with title, body, and labels fields."}
+    ) catch {};
 }
 
 fn handleGetProjectState(
@@ -607,26 +514,20 @@ fn handleCreateIssue(
         writeErr(alloc, out, "missing title");
         return;
     };
-    const raw_body = mj.getStr(args, "body") orelse {
-        writeErr(alloc, out, "missing body");
-        return;
-    };
-    if (validateIssueDraft(alloc, title, raw_body)) |msg| {
-        defer alloc.free(msg);
-        writeErr(alloc, out, msg);
-        return;
-    }
 
-    // Build body — optionally append parent issue reference as plain body context.
-    const parent_issue: ?i64 = if (args.get("parent_issue")) |piv|
-        if (piv == .integer) piv.integer else null
-    else
-        null;
-    const body = buildIssueBody(alloc, raw_body, parent_issue) orelse {
-        writeErr(alloc, out, "failed to allocate issue body");
-        return;
+    // Build body — optionally append parent issue reference
+    var body_buf: ?[]u8 = null;
+    defer if (body_buf) |b| alloc.free(b);
+    const body: []const u8 = blk: {
+        const raw = mj.getStr(args, "body") orelse "";
+        if (args.get("parent_issue")) |piv| {
+            if (piv == .integer) {
+                body_buf = std.fmt.allocPrint(alloc, "{s}\n\nParent issue: #{d}", .{ raw, piv.integer }) catch null;
+                if (body_buf) |b| break :blk b;
+            }
+        }
+        break :blk raw;
     };
-    defer alloc.free(body);
 
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(alloc);
@@ -2169,57 +2070,6 @@ fn runAgentWithRole(
     runChainStep(alloc, role, mode, writable_flag, null, prompt, timeout_seconds, out);
 }
 
-fn parseTimeoutSeconds(args: *const std.json.ObjectMap, default_seconds: u32) u32 {
-    if (args.get("timeout_seconds")) |v| {
-        if (v == .integer and v.integer > 0) {
-            return @intCast(@min(v.integer, 600));
-        }
-    }
-    return default_seconds;
-}
-
-fn appendTimedOutJson(
-    alloc: std.mem.Allocator,
-    out: *std.ArrayList(u8),
-    timeout_seconds: u32,
-) void {
-    var ts_buf: [16]u8 = undefined;
-    const ts = std.fmt.bufPrint(&ts_buf, "{d}", .{timeout_seconds}) catch "300";
-    out.appendSlice(alloc, "{\"timed_out\":true,\"error\":\"agent execution exceeded timeout\",\"timeout_seconds\":") catch {};
-    out.appendSlice(alloc, ts) catch {};
-    out.appendSlice(alloc, "}") catch {};
-}
-
-fn isTimedOutPayload(text: []const u8) bool {
-    return std.mem.startsWith(u8, std.mem.trim(u8, text, " \t\n\r"), "{\"timed_out\"");
-}
-
-fn remainingTimeoutSeconds(start_ms: i64, total_seconds: u32) ?u32 {
-    const total_ms = @as(i64, total_seconds) * std.time.ms_per_s;
-    const elapsed_ms = @max(@as(i64, 0), std.time.milliTimestamp() - start_ms);
-    if (elapsed_ms >= total_ms) return null;
-    const remaining_ms = total_ms - elapsed_ms;
-    return @intCast(@max(@as(i64, 1), @divFloor(remaining_ms + std.time.ms_per_s - 1, std.time.ms_per_s)));
-}
-
-fn runChainStepWithBudget(
-    alloc: std.mem.Allocator,
-    role: []const u8,
-    mode: ?[]const u8,
-    writable_override: ?bool,
-    permission_mode: ?[]const u8,
-    prompt: []const u8,
-    start_ms: i64,
-    total_timeout_seconds: u32,
-    step_out: *std.ArrayList(u8),
-) void {
-    const remaining = remainingTimeoutSeconds(start_ms, total_timeout_seconds) orelse {
-        appendTimedOutJson(alloc, step_out, total_timeout_seconds);
-        return;
-    };
-    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, remaining, step_out);
-}
-
 fn handleRunReviewer(
     alloc: std.mem.Allocator,
     args: *const std.json.ObjectMap,
@@ -2231,7 +2081,14 @@ fn handleRunReviewer(
             "Zig 0.15.x API (ArrayList.empty, append(alloc,v), deinit(alloc)), " ++
             "PPR push rule correctness, and missing test coverage. " ++
             "Lead with concrete findings, include file:line references.";
-    const timeout_seconds: ?u32 = parseTimeoutSeconds(args, 300);
+    const timeout_seconds: ?u32 = blk: {
+        if (args.get("timeout_seconds")) |v| {
+            if (v == .integer and v.integer > 0) {
+                break :blk @intCast(@min(v.integer, 600));
+            }
+        }
+        break :blk 300;
+    };
     runAgentWithRole(alloc, "reviewer", null, false, prompt, timeout_seconds, out);
 }
 
@@ -2244,8 +2101,7 @@ fn handleRunExplorer(
         writeErr(alloc, out, "run_explorer requires a prompt argument");
         return;
     };
-    const timeout_seconds: ?u32 = parseTimeoutSeconds(args, 300);
-    runAgentWithRole(alloc, "explorer", null, false, prompt, timeout_seconds, out);
+    runAgentWithRole(alloc, "explorer", null, false, prompt, 300, out);
 }
 
 fn handleRunZigInfra(
@@ -2445,6 +2301,7 @@ fn handleReviewFixLoop(
     }
 }
 
+
 // ── run_agents: batch parallel agent execution ────────────────────────────────
 //
 // Each agent spec runs in its own Zig thread (via page_allocator to avoid
@@ -2524,13 +2381,9 @@ fn handleRunAgents(
             else => {
                 specs[i] = .{
                     .prompt = "",
-                    .model = null,
-                    .role = null,
-                    .mode = null,
-                    .writable = null,
-                    .allowed_tools = null,
-                    .permission_mode = null,
-                    .cwd = null,
+                    .model = null, .role = null, .mode = null,
+                    .writable = null, .allowed_tools = null,
+                    .permission_mode = null, .cwd = null,
                 };
                 threads[i] = null;
                 continue;
@@ -2635,15 +2488,6 @@ fn handleRunAgent(
     defer if (enriched) |e| alloc.free(e);
 
     const final_prompt = enriched orelse prompt;
-    const requested_writable: ?bool = blk: {
-        if (args.get("writable")) |v|
-            if (v == .bool) break :blk v.bool;
-        break :blk null;
-    };
-    const effective_writable: ?bool = if ((requested_writable orelse false) and isExplicitNoEditProbe(final_prompt))
-        false
-    else
-        requested_writable;
 
     // Build AgentRequest from MCP params
     const req: rt.AgentRequest = .{
@@ -2654,7 +2498,11 @@ fn handleRunAgent(
         .allowed_tools = mj.getStr(args, "allowed_tools"),
         .permission_mode = mj.getStr(args, "permission_mode"),
         .cwd = mj.getStr(args, "cwd"),
-        .writable = effective_writable,
+        .writable = blk: {
+            if (args.get("writable")) |v|
+                if (v == .bool) break :blk v.bool;
+            break :blk null;
+        },
     };
 
     // resolve() picks backend + model + tools; dispatch() spawns
@@ -2662,20 +2510,6 @@ fn handleRunAgent(
     defer rt.prompts.freeAssembled(alloc, resolved.system_prompt);
 
     rt.dispatch.dispatch(alloc, resolved, final_prompt, out);
-}
-
-fn isExplicitNoEditProbe(prompt: []const u8) bool {
-    const no_edit =
-        std.mem.indexOf(u8, prompt, "Do not edit files") != null or
-        std.mem.indexOf(u8, prompt, "do not edit files") != null or
-        std.mem.indexOf(u8, prompt, "don't edit files") != null or
-        std.mem.indexOf(u8, prompt, "no file edits") != null;
-    const probe =
-        std.mem.indexOf(u8, prompt, "Reply with exactly") != null or
-        std.mem.indexOf(u8, prompt, "reply with exactly") != null or
-        std.mem.indexOf(u8, prompt, "smoke test") != null or
-        std.mem.indexOf(u8, prompt, "no-op probe") != null;
-    return no_edit and probe;
 }
 
 // ── run_task: smart executor with chain presets (#278) ────────────────────────
@@ -2705,8 +2539,7 @@ fn runChainStep(
     writable_override: ?bool,
     permission_mode: ?[]const u8,
     prompt: []const u8,
-    timeout_ms: u64,
-    reported_timeout_seconds: u32,
+    timeout_seconds: ?u32,
     step_out: *std.ArrayList(u8),
 ) void {
     const rt = @import("runtime.zig");
@@ -2718,37 +2551,26 @@ fn runChainStep(
         .permission_mode = permission_mode,
     };
     const resolved = rt.resolve.resolveWithProbe(alloc, req);
+    defer rt.prompts.freeAssembled(alloc, resolved.system_prompt);
 
-    const timeout_ns = timeout_ms * std.time.ns_per_ms;
+    const timeout_ns = @as(u64, timeout_seconds orelse 300) * std.time.ns_per_s;
 
     const Ctx = struct {
         alloc: std.mem.Allocator,
         resolved: rt.ResolvedAgent,
         prompt: []const u8,
-        out: std.ArrayList(u8),
+        out: *std.ArrayList(u8),
         done: std.Thread.ResetEvent,
-        mu: std.Thread.Mutex,
-        completed: bool,
-        cleanup_in_worker: bool,
-        fn cleanup(ctx: *@This()) void {
-            ctx.out.deinit(ctx.alloc);
-            rt.prompts.freeAssembled(ctx.alloc, ctx.resolved.system_prompt);
-            ctx.alloc.destroy(ctx);
-        }
         fn run(ctx: *@This()) void {
-            rt.dispatch.dispatch(ctx.alloc, ctx.resolved, ctx.prompt, &ctx.out);
-            var cleanup_now = false;
-            ctx.mu.lock();
-            ctx.completed = true;
-            cleanup_now = ctx.cleanup_in_worker;
-            ctx.mu.unlock();
+            rt.dispatch.dispatch(ctx.alloc, ctx.resolved, ctx.prompt, ctx.out);
             ctx.done.set();
-            if (cleanup_now) ctx.cleanup();
         }
     };
 
+    // Heap-allocate ctx so the thread can safely outlive this function on timeout.
+    // Without this, a timeout returns and frees the stack frame while the thread
+    // still holds &ctx — a use-after-free.
     const ctx = alloc.create(Ctx) catch {
-        rt.prompts.freeAssembled(alloc, resolved.system_prompt);
         step_out.appendSlice(alloc, "{\"error\":\"OOM: failed to allocate agent context\"}") catch {};
         return;
     };
@@ -2756,22 +2578,18 @@ fn runChainStep(
         .alloc = alloc,
         .resolved = resolved,
         .prompt = prompt,
-        .out = .empty,
+        .out = step_out,
         .done = .{},
-        .mu = .{},
-        .completed = false,
-        .cleanup_in_worker = false,
     };
 
     const thread = std.Thread.spawn(.{}, Ctx.run, .{ctx}) catch {
-        rt.prompts.freeAssembled(alloc, resolved.system_prompt);
         alloc.destroy(ctx);
         step_out.appendSlice(alloc, "{\"error\":\"failed to spawn agent thread\"}") catch {};
         return;
     };
 
-    // Heartbeat loop: send periodic notifications every 15s to keep external
-    // MCP bridge connections alive while still enforcing the full timeout budget.
+    // Heartbeat loop: send periodic notifications/message every 15s to keep
+    // external MCP bridge connections alive (they typically timeout at ~60s).
     const notify = @import("notify.zig");
     const heartbeat_ns: u64 = 15 * std.time.ns_per_s;
     var remaining_ns: u64 = timeout_ns;
@@ -2779,34 +2597,26 @@ fn runChainStep(
     while (remaining_ns > 0) {
         const wait_ns = @min(heartbeat_ns, remaining_ns);
         if (ctx.done.timedWait(wait_ns)) |_| {
+            // Agent finished
             thread.join();
-            step_out.appendSlice(alloc, ctx.out.items) catch {};
-            ctx.cleanup();
+            alloc.destroy(ctx);
             return;
         } else |_| {
             remaining_ns -= wait_ns;
             elapsed_s += wait_ns / std.time.ns_per_s;
-            if (remaining_ns > 0) {
-                var msg_buf: [128]u8 = undefined;
-                const msg = std.fmt.bufPrint(&msg_buf, "agent '{s}' running ({d}s elapsed)", .{ role, elapsed_s }) catch "agent running";
-                notify.send(alloc, msg);
-            }
+            var msg_buf: [128]u8 = undefined;
+            const msg = std.fmt.bufPrint(&msg_buf, "agent '{s}' running ({d}s elapsed)", .{ role, elapsed_s }) catch "agent running…";
+            notify.send(alloc, msg);
         }
     }
 
-    ctx.mu.lock();
-    const completed = ctx.completed;
-    if (!completed) ctx.cleanup_in_worker = true;
-    ctx.mu.unlock();
-
-    if (completed) {
-        thread.join();
-        step_out.appendSlice(alloc, ctx.out.items) catch {};
-        ctx.cleanup();
-    } else {
-        thread.detach();
-        appendTimedOutJson(alloc, step_out, reported_timeout_seconds);
-    }
+    // Timeout — detach thread, return error
+    thread.detach();
+    var ts_buf: [16]u8 = undefined;
+    const ts = std.fmt.bufPrint(&ts_buf, "{d}", .{timeout_seconds orelse 300}) catch "300";
+    step_out.appendSlice(alloc, "{\"timed_out\":true,\"error\":\"agent execution exceeded timeout\",\"timeout_seconds\":") catch {};
+    step_out.appendSlice(alloc, ts) catch {};
+    step_out.appendSlice(alloc, "}") catch {};
 }
 
 fn handleRunTask(
@@ -2818,8 +2628,6 @@ fn handleRunTask(
         writeErr(alloc, out, "run_task requires a task argument");
         return;
     };
-    const timeout_seconds = parseTimeoutSeconds(args, 300);
-    const start_ms = std.time.milliTimestamp();
 
     const mode = mj.getStr(args, "mode");
     const writable_override: ?bool = blk: {
@@ -2863,16 +2671,13 @@ fn handleRunTask(
             ) catch task;
             defer if (finder_prompt.ptr != task.ptr) alloc.free(finder_prompt);
 
-            runChainStepWithBudget(alloc, "finder", mode, false, permission_mode, finder_prompt, start_ms, timeout_seconds, &finder_out);
+            runChainStep(alloc, "finder", mode, false, permission_mode, finder_prompt, 300, &finder_out);
 
             out.appendSlice(alloc, "{\"role\":\"finder\",\"output\":\"") catch return;
             mj.writeEscaped(alloc, out, finder_out.items);
             out.appendSlice(alloc, "\"},") catch return;
 
-            if (isTimedOutPayload(finder_out.items)) {
-                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"Skipped: finder timed out\"},") catch return;
-                out.appendSlice(alloc, "{\"role\":\"verify\",\"verdict\":\"SKIP\",\"output\":\"Finder timed out before the chain could continue\"}") catch return;
-            } else if (std.mem.trim(u8, finder_out.items, " \t\n\r").len == 0) {
+            if (std.mem.trim(u8, finder_out.items, " \t\n\r").len == 0) {
                 out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"Skipped: finder returned empty output\"}") catch return;
             } else {
                 // Step 2: contract (read-only) — define acceptance criteria before fixing
@@ -2890,7 +2695,7 @@ fn handleRunTask(
                 ) catch task;
                 defer if (contract_prompt.ptr != task.ptr) alloc.free(contract_prompt);
 
-                runChainStepWithBudget(alloc, "reviewer", mode, false, permission_mode, contract_prompt, start_ms, timeout_seconds, &contract_out);
+                runChainStep(alloc, "reviewer", mode, false, permission_mode, contract_prompt, 120, &contract_out);
 
                 out.appendSlice(alloc, "{\"role\":\"contract\",\"output\":\"") catch return;
                 mj.writeEscaped(alloc, out, contract_out.items);
@@ -2902,62 +2707,58 @@ fn handleRunTask(
                     out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"Skipped: contract returned empty or timed out\"},") catch return;
                     out.appendSlice(alloc, "{\"role\":\"verify\",\"verdict\":\"SKIP\",\"output\":\"No contract to verify against\"}") catch return;
                 } else {
-                    // Step 3: fixer (writable) — apply changes against the contract
-                    var fixer_out: std.ArrayList(u8) = .empty;
-                    defer fixer_out.deinit(alloc);
-                    const fixer_prompt = std.fmt.allocPrint(
-                        alloc,
-                        "Fix the following task. You MUST satisfy all acceptance criteria in the contract.\n\n" ++
-                            "TASK: {s}\n\nFINDINGS:\n{s}\n\nACCEPTANCE CRITERIA (you must pass ALL):\n{s}",
-                        .{ task, finder_out.items, contract_out.items },
-                    ) catch task;
-                    defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
+                // Step 3: fixer (writable) — apply changes against the contract
+                var fixer_out: std.ArrayList(u8) = .empty;
+                defer fixer_out.deinit(alloc);
+                const fixer_prompt = std.fmt.allocPrint(
+                    alloc,
+                    "Fix the following task. You MUST satisfy all acceptance criteria in the contract.\n\n" ++
+                        "TASK: {s}\n\nFINDINGS:\n{s}\n\nACCEPTANCE CRITERIA (you must pass ALL):\n{s}",
+                    .{ task, finder_out.items, contract_out.items },
+                ) catch task;
+                defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
 
-                    runChainStepWithBudget(alloc, "fixer", mode, writable_override orelse true, permission_mode, fixer_prompt, start_ms, timeout_seconds, &fixer_out);
+                runChainStep(alloc, "fixer", mode, writable_override orelse true, permission_mode, fixer_prompt, 300, &fixer_out);
 
-                    out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
-                    mj.writeEscaped(alloc, out, fixer_out.items);
-                    out.appendSlice(alloc, "\"},") catch return;
+                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
+                mj.writeEscaped(alloc, out, fixer_out.items);
+                out.appendSlice(alloc, "\"},") catch return;
 
-                    if (isTimedOutPayload(fixer_out.items)) {
-                        out.appendSlice(alloc, "{\"role\":\"verify\",\"verdict\":\"SKIP\",\"output\":\"Fixer timed out before verification\"}") catch return;
-                    } else {
-                        // Step 4: verify (read-only) — score the fix against the contract
-                        var verify_out: std.ArrayList(u8) = .empty;
-                        defer verify_out.deinit(alloc);
+                // Step 4: verify (read-only) — score the fix against the contract
+                var verify_out: std.ArrayList(u8) = .empty;
+                defer verify_out.deinit(alloc);
 
-                        const verify_prompt = std.fmt.allocPrint(
-                            alloc,
-                            "You are verifying a fix against its sprint contract. " ++
-                                "Score each axis 1-10 and PASS or FAIL.\n\n" ++
-                                "GRADING AXES:\n" ++
-                                "  CORRECTNESS (threshold 8): does the fix compile and not break existing tests?\n" ++
-                                "  SAFETY (threshold 9): does the fix resolve the safety issue without introducing new ones?\n" ++
-                                "  COMPLETENESS (threshold 7): does the fix satisfy ALL acceptance criteria?\n" ++
-                                "  QUALITY (threshold 6): is the fix minimal and clean, not over-engineered?\n\n" ++
-                                "OUTPUT: SCORES: correctness=N safety=N completeness=N quality=N\n" ++
-                                "PASS or FAIL, then explain what passed/failed and why.\n\n" ++
-                                "TASK: {s}\n\nACCEPTANCE CRITERIA:\n{s}\n\nFIXER OUTPUT:\n{s}",
-                            .{ task, contract_out.items, fixer_out.items },
-                        ) catch task;
-                        defer if (verify_prompt.ptr != task.ptr) alloc.free(verify_prompt);
+                const verify_prompt = std.fmt.allocPrint(
+                    alloc,
+                    "You are verifying a fix against its sprint contract. " ++
+                        "Score each axis 1-10 and PASS or FAIL.\n\n" ++
+                        "GRADING AXES:\n" ++
+                        "  CORRECTNESS (threshold 8): does the fix compile and not break existing tests?\n" ++
+                        "  SAFETY (threshold 9): does the fix resolve the safety issue without introducing new ones?\n" ++
+                        "  COMPLETENESS (threshold 7): does the fix satisfy ALL acceptance criteria?\n" ++
+                        "  QUALITY (threshold 6): is the fix minimal and clean, not over-engineered?\n\n" ++
+                        "OUTPUT: SCORES: correctness=N safety=N completeness=N quality=N\n" ++
+                        "PASS or FAIL, then explain what passed/failed and why.\n\n" ++
+                        "TASK: {s}\n\nACCEPTANCE CRITERIA:\n{s}\n\nFIXER OUTPUT:\n{s}",
+                    .{ task, contract_out.items, fixer_out.items },
+                ) catch task;
+                defer if (verify_prompt.ptr != task.ptr) alloc.free(verify_prompt);
 
-                        runChainStepWithBudget(alloc, "reviewer", mode, false, permission_mode, verify_prompt, start_ms, timeout_seconds, &verify_out);
+                runChainStep(alloc, "reviewer", mode, false, permission_mode, verify_prompt, 180, &verify_out);
 
-                        // Parse verify verdict
-                        const verify_text = verify_out.items;
-                        const verify_pass = std.mem.indexOf(u8, verify_text, "\nPASS\n") != null or
-                            std.mem.indexOf(u8, verify_text, "\nPASS\r") != null or
-                            std.mem.startsWith(u8, std.mem.trim(u8, verify_text, " \t\n\r"), "PASS\n") or
-                            std.mem.eql(u8, std.mem.trim(u8, verify_text, " \t\n\r"), "PASS") or
-                            std.mem.indexOf(u8, verify_text, "NO_ISSUES_FOUND") != null;
+                // Parse verify verdict
+                const verify_text = verify_out.items;
+                const verify_pass = std.mem.indexOf(u8, verify_text, "\nPASS\n") != null or
+                    std.mem.indexOf(u8, verify_text, "\nPASS\r") != null or
+                    std.mem.startsWith(u8, std.mem.trim(u8, verify_text, " \t\n\r"), "PASS\n") or
+                    std.mem.eql(u8, std.mem.trim(u8, verify_text, " \t\n\r"), "PASS") or
+                    std.mem.indexOf(u8, verify_text, "NO_ISSUES_FOUND") != null;
 
-                        out.appendSlice(alloc, "{\"role\":\"verify\",\"verdict\":\"") catch return;
-                        out.appendSlice(alloc, if (verify_pass) "PASS" else "FAIL") catch return;
-                        out.appendSlice(alloc, "\",\"output\":\"") catch return;
-                        mj.writeEscaped(alloc, out, verify_out.items);
-                        out.appendSlice(alloc, "\"}") catch return;
-                    }
+                out.appendSlice(alloc, "{\"role\":\"verify\",\"verdict\":\"") catch return;
+                out.appendSlice(alloc, if (verify_pass) "PASS" else "FAIL") catch return;
+                out.appendSlice(alloc, "\",\"output\":\"") catch return;
+                mj.writeEscaped(alloc, out, verify_out.items);
+                out.appendSlice(alloc, "\"}") catch return;
                 } // close else (contract not empty)
             }
         },
@@ -2982,7 +2783,7 @@ fn handleRunTask(
             ) catch task;
             defer if (scored_review_prompt.ptr != task.ptr) alloc.free(scored_review_prompt);
 
-            runChainStepWithBudget(alloc, "reviewer", mode, false, permission_mode, scored_review_prompt, start_ms, timeout_seconds, &review_out);
+            runChainStep(alloc, "reviewer", mode, false, permission_mode, scored_review_prompt, 300, &review_out);
 
             out.appendSlice(alloc, "{\"role\":\"reviewer\",\"output\":\"") catch return;
             mj.writeEscaped(alloc, out, review_out.items);
@@ -2990,37 +2791,33 @@ fn handleRunTask(
 
             // Check convergence
             const review_text = review_out.items;
-            if (isTimedOutPayload(review_text)) {
-                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"Skipped: reviewer timed out\"}") catch return;
+            const is_pass = std.mem.indexOf(u8, review_text, "\nPASS\n") != null or
+                std.mem.indexOf(u8, review_text, "\nPASS\r") != null or
+                std.mem.startsWith(u8, std.mem.trim(u8, review_text, " \t\n\r"), "PASS\n") or
+                std.mem.eql(u8, std.mem.trim(u8, review_text, " \t\n\r"), "PASS");
+            const no_issues = std.mem.indexOf(u8, review_text, "NO_ISSUES_FOUND") != null;
+
+            if (is_pass or no_issues or std.mem.trim(u8, review_text, " \t\n\r").len == 0) {
+                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"No issues to fix — all axes passed\"}") catch return;
             } else {
-                const is_pass = std.mem.indexOf(u8, review_text, "\nPASS\n") != null or
-                    std.mem.indexOf(u8, review_text, "\nPASS\r") != null or
-                    std.mem.startsWith(u8, std.mem.trim(u8, review_text, " \t\n\r"), "PASS\n") or
-                    std.mem.eql(u8, std.mem.trim(u8, review_text, " \t\n\r"), "PASS");
-                const no_issues = std.mem.indexOf(u8, review_text, "NO_ISSUES_FOUND") != null;
+                // Step 2: fixer (writable) — fix found issues, must address all FAIL axes
+                var fixer_out: std.ArrayList(u8) = .empty;
+                defer fixer_out.deinit(alloc);
 
-                if (is_pass or no_issues or std.mem.trim(u8, review_text, " \t\n\r").len == 0) {
-                    out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"No issues to fix — all axes passed\"}") catch return;
-                } else {
-                    // Step 2: fixer (writable) — fix found issues, must address all FAIL axes
-                    var fixer_out: std.ArrayList(u8) = .empty;
-                    defer fixer_out.deinit(alloc);
+                const fixer_prompt = std.fmt.allocPrint(
+                    alloc,
+                    "Fix ALL issues listed below. The reviewer scored axes and FAILed — " ++
+                        "you must address every finding to bring all axes above threshold.\n\n" ++
+                        "REVIEW FINDINGS:\n{s}",
+                    .{review_out.items},
+                ) catch task;
+                defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
 
-                    const fixer_prompt = std.fmt.allocPrint(
-                        alloc,
-                        "Fix ALL issues listed below. The reviewer scored axes and FAILed — " ++
-                            "you must address every finding to bring all axes above threshold.\n\n" ++
-                            "REVIEW FINDINGS:\n{s}",
-                        .{review_out.items},
-                    ) catch task;
-                    defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
+                runChainStep(alloc, "fixer", mode, writable_override orelse true, permission_mode, fixer_prompt, 300, &fixer_out);
 
-                    runChainStepWithBudget(alloc, "fixer", mode, writable_override orelse true, permission_mode, fixer_prompt, start_ms, timeout_seconds, &fixer_out);
-
-                    out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
-                    mj.writeEscaped(alloc, out, fixer_out.items);
-                    out.appendSlice(alloc, "\"}") catch return;
-                }
+                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
+                mj.writeEscaped(alloc, out, fixer_out.items);
+                out.appendSlice(alloc, "\"}") catch return;
             }
         },
         .explore_report => {
@@ -3028,15 +2825,13 @@ fn handleRunTask(
             var explore_out: std.ArrayList(u8) = .empty;
             defer explore_out.deinit(alloc);
 
-            runChainStepWithBudget(alloc, "explorer", mode, false, permission_mode, task, start_ms, timeout_seconds, &explore_out);
+            runChainStep(alloc, "explorer", mode, false, permission_mode, task, 300, &explore_out);
 
             out.appendSlice(alloc, "{\"role\":\"explorer\",\"output\":\"") catch return;
             mj.writeEscaped(alloc, out, explore_out.items);
             out.appendSlice(alloc, "\"},") catch return;
 
-            if (isTimedOutPayload(explore_out.items)) {
-                out.appendSlice(alloc, "{\"role\":\"synthesizer\",\"output\":\"Skipped: explorer timed out\"}") catch return;
-            } else if (std.mem.trim(u8, explore_out.items, " \t\n\r").len == 0) {
+            if (std.mem.trim(u8, explore_out.items, " \t\n\r").len == 0) {
                 out.appendSlice(alloc, "{\"role\":\"synthesizer\",\"output\":\"Skipped: explorer returned empty output\"}") catch return;
             } else {
                 // Step 2: synthesizer (read-only) — summarize findings
@@ -3050,7 +2845,7 @@ fn handleRunTask(
                 ) catch task;
                 defer if (synth_prompt.ptr != task.ptr) alloc.free(synth_prompt);
 
-                runChainStepWithBudget(alloc, "synthesizer", mode, false, permission_mode, synth_prompt, start_ms, timeout_seconds, &synth_out);
+                runChainStep(alloc, "synthesizer", mode, false, permission_mode, synth_prompt, 300, &synth_out);
 
                 out.appendSlice(alloc, "{\"role\":\"synthesizer\",\"output\":\"") catch return;
                 mj.writeEscaped(alloc, out, synth_out.items);
@@ -3062,55 +2857,46 @@ fn handleRunTask(
             var arch_out: std.ArrayList(u8) = .empty;
             defer arch_out.deinit(alloc);
 
-            runChainStepWithBudget(alloc, "architect", "deep", false, permission_mode, task, start_ms, timeout_seconds, &arch_out);
+            runChainStep(alloc, "architect", "deep", false, permission_mode, task, 300, &arch_out);
 
             out.appendSlice(alloc, "{\"role\":\"architect\",\"output\":\"") catch return;
             mj.writeEscaped(alloc, out, arch_out.items);
             out.appendSlice(alloc, "\"},") catch return;
 
-            if (isTimedOutPayload(arch_out.items)) {
-                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"Skipped: architect timed out\"},") catch return;
-                out.appendSlice(alloc, "{\"role\":\"reviewer\",\"output\":\"Skipped: architect timed out before implementation\"}") catch return;
-            } else {
-                // Step 2: fixer (writable) — implement the plan
-                var fixer_out: std.ArrayList(u8) = .empty;
-                defer fixer_out.deinit(alloc);
+            // Step 2: fixer (writable) — implement the plan
+            var fixer_out: std.ArrayList(u8) = .empty;
+            defer fixer_out.deinit(alloc);
 
-                const fixer_prompt = std.fmt.allocPrint(
-                    alloc,
-                    "Implement the following architectural plan.\n\n" ++
-                        "PLAN:\n{s}",
-                    .{arch_out.items},
-                ) catch task;
-                defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
+            const fixer_prompt = std.fmt.allocPrint(
+                alloc,
+                "Implement the following architectural plan.\n\n" ++
+                    "PLAN:\n{s}",
+                .{arch_out.items},
+            ) catch task;
+            defer if (fixer_prompt.ptr != task.ptr) alloc.free(fixer_prompt);
 
-                runChainStepWithBudget(alloc, "fixer", mode, writable_override orelse true, permission_mode, fixer_prompt, start_ms, timeout_seconds, &fixer_out);
+            runChainStep(alloc, "fixer", mode, writable_override orelse true, permission_mode, fixer_prompt, 300, &fixer_out);
 
-                out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
-                mj.writeEscaped(alloc, out, fixer_out.items);
-                out.appendSlice(alloc, "\"},") catch return;
+            out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
+            mj.writeEscaped(alloc, out, fixer_out.items);
+            out.appendSlice(alloc, "\"},") catch return;
 
-                if (isTimedOutPayload(fixer_out.items)) {
-                    out.appendSlice(alloc, "{\"role\":\"reviewer\",\"output\":\"Skipped: fixer timed out before review\"}") catch return;
-                } else {
-                    // Step 3: reviewer (read-only) — verify implementation
-                    var review_out: std.ArrayList(u8) = .empty;
-                    defer review_out.deinit(alloc);
+            // Step 3: reviewer (read-only) — verify implementation
+            var review_out: std.ArrayList(u8) = .empty;
+            defer review_out.deinit(alloc);
 
-                    runChainStepWithBudget(alloc, "reviewer", mode, false, permission_mode, task, start_ms, timeout_seconds, &review_out);
+            runChainStep(alloc, "reviewer", mode, false, permission_mode, task, 300, &review_out);
 
-                    out.appendSlice(alloc, "{\"role\":\"reviewer\",\"output\":\"") catch return;
-                    mj.writeEscaped(alloc, out, review_out.items);
-                    out.appendSlice(alloc, "\"}") catch return;
-                }
-            }
+            out.appendSlice(alloc, "{\"role\":\"reviewer\",\"output\":\"") catch return;
+            mj.writeEscaped(alloc, out, review_out.items);
+            out.appendSlice(alloc, "\"}") catch return;
         },
         .custom => {
             // Custom: just run as a single agent with the task
             var step_out: std.ArrayList(u8) = .empty;
             defer step_out.deinit(alloc);
 
-            runChainStepWithBudget(alloc, "fixer", mode, writable_override orelse true, permission_mode, task, start_ms, timeout_seconds, &step_out);
+            runChainStep(alloc, "fixer", mode, writable_override orelse true, permission_mode, task, 300, &step_out);
 
             out.appendSlice(alloc, "{\"role\":\"fixer\",\"output\":\"") catch return;
             mj.writeEscaped(alloc, out, step_out.items);
@@ -3119,99 +2905,4 @@ fn handleRunTask(
     }
 
     out.appendSlice(alloc, "]}") catch return;
-}
-
-test "tools_list encodes evidence-backed issue filing guidance" {
-    try std.testing.expect(std.mem.indexOf(u8, tools_list, "This tool enforces the issue requirements from CONTRIBUTING.md and AGENT.md") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tools_list, "Each issue body must satisfy the same CONTRIBUTING.md / AGENT.md evidence template enforced by create_issue") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tools_list, "CONTRIBUTING.md and AGENT.md") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tools_list, "run_explorer") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tools_list, "Maximum time for agent execution (default 300, max 600)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, tools_list, "Maximum total time for the full chain (default 300, max 600)") != null);
-}
-
-test "remainingTimeoutSeconds rounds up and expires cleanly" {
-    const now = std.time.milliTimestamp();
-
-    // Stay comfortably away from millisecond boundaries so the test cannot
-    // flap if a few ms elapse between capturing `now` and evaluating.
-    try std.testing.expectEqual(@as(?u32, 3), remainingTimeoutSeconds(now - 1001, 4));
-    try std.testing.expectEqual(@as(?u32, 1), remainingTimeoutSeconds(now - 3001, 4));
-    try std.testing.expectEqual(@as(?u32, null), remainingTimeoutSeconds(now - 5000, 4));
-}
-
-test "appendTimedOutJson emits timeout payload" {
-    const alloc = std.testing.allocator;
-    var out: std.ArrayList(u8) = .empty;
-    defer out.deinit(alloc);
-
-    appendTimedOutJson(alloc, &out, 42);
-
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"timed_out\":true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"timeout_seconds\":42") != null);
-}
-
-test "isTimedOutPayload accepts trimmed timeout json" {
-    try std.testing.expect(isTimedOutPayload("  \n{\"timed_out\":true,\"timeout_seconds\":2}"));
-    try std.testing.expect(!isTimedOutPayload("{\"error\":\"not timeout\"}"));
-}
-
-test "handleDecomposeFeature includes issue discovery standard" {
-    const alloc = std.testing.allocator;
-    setCurrentRepo("justrach/devswarm");
-
-    var args = std.json.ObjectMap.init(alloc);
-    defer args.deinit();
-    try args.put("feature_description", .{ .string = "add full-text search" });
-
-    var out: std.ArrayList(u8) = .empty;
-    defer out.deinit(alloc);
-
-    handleDecomposeFeature(alloc, &args, &out);
-
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"issue_discovery_standard\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"issue_template\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "runtime-verifiable evidence") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "Nearby passing checks") != null);
-}
-
-test "validateIssueDraft rejects missing sections" {
-    const alloc = std.testing.allocator;
-    const msg = validateIssueDraft(alloc, "title", "## Exact repro\nonly one section\n") orelse return error.ExpectedValidationError;
-    defer alloc.free(msg);
-
-    try std.testing.expect(std.mem.indexOf(u8, msg, "Missing required section") != null);
-    try std.testing.expect(std.mem.indexOf(u8, msg, "## Observed result") != null);
-}
-
-test "validateIssueDraft accepts complete template" {
-    const alloc = std.testing.allocator;
-    const body =
-        "## One-sentence problem\none problem\n\n" ++
-        "## Exact repro\nrun x\n\n" ++
-        "## Observed result\nfails with y\n\n" ++
-        "## Expected result\nshould do z\n\n" ++
-        "## Nearby passing checks\n- check a\n\n" ++
-        "## Acceptance criteria\n- fix x\n\n" ++
-        "## Non-goals\n- not doing q\n";
-
-    try std.testing.expectEqual(@as(?[]u8, null), validateIssueDraft(alloc, "title", body));
-}
-
-test "buildIssueBody appends parent issue annotation for context only" {
-    const alloc = std.testing.allocator;
-    const body =
-        "## One-sentence problem\none problem\n\n" ++
-        "## Exact repro\nrun x\n\n" ++
-        "## Observed result\nfails with y\n\n" ++
-        "## Expected result\nshould do z\n\n" ++
-        "## Nearby passing checks\n- check a\n\n" ++
-        "## Acceptance criteria\n- fix x\n\n" ++
-        "## Non-goals\n- not doing q\n";
-
-    const with_parent = buildIssueBody(alloc, body, 393) orelse return error.OutOfMemory;
-    defer alloc.free(with_parent);
-
-    try std.testing.expect(std.mem.endsWith(u8, with_parent, "\n\nParent issue: #393"));
-    try std.testing.expect(std.mem.indexOf(u8, with_parent, "## Acceptance criteria") != null);
 }

--- a/test_e2e.py
+++ b/test_e2e.py
@@ -7,28 +7,6 @@ _DIR   = Path(__file__).resolve().parent
 BINARY = str(_DIR / "zig-out" / "bin" / "devswarm")
 REPO   = str(_DIR)
 
-ISSUE_BODY = """## One-sentence problem
-E2E issue template validation path.
-
-## Exact repro
-Run the devswarm MCP e2e issue-management flow.
-
-## Observed result
-The issue-management tools create and update GitHub issues.
-
-## Expected result
-The tools accept a complete evidence-backed issue body.
-
-## Nearby passing checks
-- get_next_task returns structured output
-
-## Acceptance criteria
-- create_issue succeeds with a complete issue template body
-
-## Non-goals
-- validating unrelated runtime behavior
-"""
-
 class MCP:
     def __init__(self):
         env = {**os.environ, "REPO_PATH": REPO}
@@ -112,7 +90,7 @@ def check(name, result, detail="", **expects):
 
 def run():
     s = MCP()
-    alpha = beta = gamma = child = None
+    alpha = beta = gamma = None
     branch_name = None; pr_num = None; orig_branch = "main"
 
     try:
@@ -202,30 +180,15 @@ def run():
         print("\n[2/5] Issue management")
 
         r = s.call("create_issue", title="[TEST] MCP e2e alpha",
-                   body=ISSUE_BODY, labels=["type:infra"])
+                   body="E2E test.", labels=["type:infra"])
         r = check("create_issue", r,
                   detail=f"#{r.get('number')} {r.get('url','')}" if isinstance(r,dict) else "",
                   number=lambda x: x and x > 0)
         if r and "number" in r: alpha = r["number"]
 
-        if alpha:
-            r = s.call("create_issue", title="[TEST] MCP e2e child",
-                       body=ISSUE_BODY, labels=["type:infra"], parent_issue=alpha)
-            r = check("create_issue (parent_issue)", r,
-                      detail=f"#{r.get('number')} parent=#{alpha}" if isinstance(r,dict) else "",
-                      number=lambda x: x and x > 0)
-            child = r["number"] if isinstance(r, dict) and "number" in r else None
-            if child:
-                r = s.call("get_issue", issue_number=child)
-                body = r.get("body", "") if isinstance(r, dict) else ""
-                if f"Parent issue: #{alpha}" in body:
-                    ok("get_issue (parent annotation)", f"child #{child} annotated with parent #{alpha}")
-                else:
-                    fail("get_issue (parent annotation)", f"missing parent annotation in body: {body[:120]!r}")
-
         r = s.call("create_issues_batch", issues=[
-            {"title":"[TEST] MCP e2e batch-beta",  "body":ISSUE_BODY,"labels":["type:infra"]},
-            {"title":"[TEST] MCP e2e batch-gamma","body":ISSUE_BODY,"labels":["type:infra"]},
+            {"title":"[TEST] MCP e2e batch-beta",  "body":"batch 1","labels":["type:infra"]},
+            {"title":"[TEST] MCP e2e batch-gamma","body":"batch 2","labels":["type:infra"]},
         ])
         if isinstance(r, list) and len(r)==2 and all(isinstance(i,dict) and i.get("number",0)>0 for i in r):
             beta=r[0]["number"]; gamma=r[1]["number"]
@@ -254,10 +217,6 @@ def run():
         if gamma:
             r = s.call("close_issue", issue_number=gamma)
             check("close_issue", r, detail=f"#{gamma}", closed=lambda x: x==gamma)
-
-        if child:
-            r = s.call("close_issue", issue_number=child)
-            check("close_issue (child)", r, detail=f"#{child}", closed=lambda x: x==child)
 
         print("\n[3/5] Branch & commit workflow")
 


### PR DESCRIPTION
This reverts the accidental merge of #403 into `main`.

Context:
- #403 was supposed to remain as a PR for review, not be merged directly.
- This PR cleanly reverts merge commit `1238f0b3ba382a7fb36cb07d3e7c9b0a8064842d`.

After this merges, the work can be reopened on a proper feature branch and submitted again for review.