### PR TITLE
fix: macOS zig build wrapper + runChainStep timeout args

### DIFF
--- a/scripts/zig-build.sh
+++ b/scripts/zig-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run `zig build` with a macOS SDK that works with Zig 0.15's bundled lld.
+#
+# On Apple Silicon with Xcode 26.x, the default SDK can make `zig build` fail
+# while linking the *build runner* (undefined symbols from libSystem such as
+# __availability_version_check, _abort, _dispatch_*). Pointing DEVELOPER_DIR at
+# Command Line Tools makes `xcrun --show-sdk-path` resolve to the CLT SDK and
+# avoids that failure.
+#
+# Usage: ./scripts/zig-build.sh [args passed to zig build]
+#   or:  ZIG=path/to/zig ./scripts/zig-build.sh test
+
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  export DEVELOPER_DIR="${DEVELOPER_DIR:-/Library/Developer/CommandLineTools}"
+fi
+
+zig="${ZIG:-zig}"
+exec "$zig" build "$@"

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -2166,7 +2166,9 @@ fn runAgentWithRole(
     timeout_seconds: ?u32,
     out: *std.ArrayList(u8),
 ) void {
-    runChainStep(alloc, role, mode, writable_flag, null, prompt, timeout_seconds, out);
+    const sec: u32 = timeout_seconds orelse 300;
+    const ms: u64 = @as(u64, sec) * std.time.ms_per_s;
+    runChainStep(alloc, role, mode, writable_flag, null, prompt, ms, sec, out);
 }
 
 fn parseTimeoutSeconds(args: *const std.json.ObjectMap, default_seconds: u32) u32 {
@@ -2217,7 +2219,7 @@ fn runChainStepWithBudget(
         appendTimedOutJson(alloc, step_out, total_timeout_seconds);
         return;
     };
-    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, remaining, step_out);
+    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, @as(u64, remaining) * std.time.ms_per_s, remaining, step_out);
 }
 
 fn handleRunReviewer(
@@ -2381,7 +2383,7 @@ fn handleReviewFixLoop(
         iter_json.appendSlice(alloc, ",\"review\":\"") catch return;
         var review_out: std.ArrayList(u8) = .empty;
         defer review_out.deinit(alloc);
-        runChainStep(alloc, "reviewer", null, false, null, review_prompt, 300, &review_out);
+        runChainStep(alloc, "reviewer", null, false, null, review_prompt, 300 * std.time.ms_per_s, 300, &review_out);
 
         mj.writeEscaped(alloc, &iter_json, review_out.items);
         iter_json.appendSlice(alloc, "\"") catch return;
@@ -2424,7 +2426,7 @@ fn handleReviewFixLoop(
 
         var fix_out: std.ArrayList(u8) = .empty;
         defer fix_out.deinit(alloc);
-        runChainStep(alloc, "fixer", null, true, null, fix_prompt, 300, &fix_out);
+        runChainStep(alloc, "fixer", null, true, null, fix_prompt, 300 * std.time.ms_per_s, 300, &fix_out);
 
         iter_json.appendSlice(alloc, ",\"fix\":\"") catch return;
         mj.writeEscaped(alloc, &iter_json, fix_out.items);


### PR DESCRIPTION
## Summary
- Adds `scripts/zig-build.sh` so macOS uses Command Line Tools (`DEVELOPER_DIR`) and Zig 0.15 can link the build runner.
- Fixes `runChainStep` call sites to pass `timeout_ms` and `reported_timeout_seconds`.

## Tests
- `./scripts/zig-build.sh`
- `./scripts/zig-build.sh test`

Made with [Cursor](https://cursor.com)