### PR TITLE
fix: saveToFile allocator (#405), runChainStep + macOS zig-build

### DIFF
--- a/scripts/zig-build.sh
+++ b/scripts/zig-build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# macOS: set DEVELOPER_DIR so Zig 0.15 can link the build runner (see PR #406).
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  export DEVELOPER_DIR="${DEVELOPER_DIR:-/Library/Developer/CommandLineTools}"
+fi
+exec "${ZIG:-zig}" build "$@"

--- a/src/graph/storage.zig
+++ b/src/graph/storage.zig
@@ -188,20 +188,15 @@ pub fn deserialize(reader: anytype, alloc: std.mem.Allocator) !CodeGraph {
 
 // ── File I/O convenience ────────────────────────────────────────────────────
 
-/// Save a CodeGraph to a file path.
-pub fn saveToFile(g: *const CodeGraph, path: []const u8) !void {
+/// Save a CodeGraph to a file path. `alloc` is used for the serialization buffer.
+pub fn saveToFile(g: *const CodeGraph, path: []const u8, alloc: std.mem.Allocator) !void {
     const file = try std.fs.cwd().createFile(path, .{});
     defer file.close();
-    // Serialize to in-memory buffer, then write all at once
     var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(alloc_for_save);
-    try serialize(g, buf.writer(alloc_for_save));
+    defer buf.deinit(alloc);
+    try serialize(g, buf.writer(alloc));
     try file.writeAll(buf.items);
 }
-
-/// Temporary allocator for saveToFile — uses page_allocator since we
-/// don't have access to a caller-provided allocator in the current API.
-const alloc_for_save = std.heap.page_allocator;
 
 /// Load a CodeGraph from a file path.
 pub fn loadFromFile(path: []const u8, alloc: std.mem.Allocator) !CodeGraph {
@@ -878,4 +873,31 @@ test "round-trip with empty strings everywhere" {
     try std.testing.expectEqualStrings("", g2.getFile(1).?.path);
     try std.testing.expectEqualStrings("", g2.getCommit(1).?.author);
     try std.testing.expectEqualStrings("", g2.getCommit(1).?.message);
+}
+
+test "saveToFile and loadFromFile round-trip (#405)" {
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_abs = try tmp.dir.realpath(".", &dir_buf);
+    const path = try std.fs.path.join(alloc, &.{ dir_abs, "cgdb405.bin" });
+    defer alloc.free(path);
+
+    var g = CodeGraph.init(alloc);
+    defer g.deinit();
+    try g.addSymbol(.{ .id = 1, .name = "main", .kind = .function, .file_id = 1, .line = 1, .col = 0, .scope = "" });
+    try g.addFile(.{ .id = 1, .path = "src/x.zig", .language = .zig, .last_modified = 1, .hash = [_]u8{0} ** 32 });
+
+    try saveToFile(&g, path, alloc);
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    var g2 = try loadFromFile(path, alloc);
+    defer g2.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), g2.symbolCount());
+    try std.testing.expectEqualStrings("main", g2.getSymbol(1).?.name);
+    try std.testing.expectEqualStrings("src/x.zig", g2.getFile(1).?.path);
 }

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -2166,7 +2166,9 @@ fn runAgentWithRole(
     timeout_seconds: ?u32,
     out: *std.ArrayList(u8),
 ) void {
-    runChainStep(alloc, role, mode, writable_flag, null, prompt, timeout_seconds, out);
+    const sec: u32 = timeout_seconds orelse 300;
+    const ms: u64 = @as(u64, sec) * std.time.ms_per_s;
+    runChainStep(alloc, role, mode, writable_flag, null, prompt, ms, sec, out);
 }
 
 fn parseTimeoutSeconds(args: *const std.json.ObjectMap, default_seconds: u32) u32 {
@@ -2217,7 +2219,7 @@ fn runChainStepWithBudget(
         appendTimedOutJson(alloc, step_out, total_timeout_seconds);
         return;
     };
-    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, remaining, step_out);
+    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, @as(u64, remaining) * std.time.ms_per_s, remaining, step_out);
 }
 
 fn handleRunReviewer(
@@ -2381,7 +2383,7 @@ fn handleReviewFixLoop(
         iter_json.appendSlice(alloc, ",\"review\":\"") catch return;
         var review_out: std.ArrayList(u8) = .empty;
         defer review_out.deinit(alloc);
-        runChainStep(alloc, "reviewer", null, false, null, review_prompt, 300, &review_out);
+        runChainStep(alloc, "reviewer", null, false, null, review_prompt, 300 * std.time.ms_per_s, 300, &review_out);
 
         mj.writeEscaped(alloc, &iter_json, review_out.items);
         iter_json.appendSlice(alloc, "\"") catch return;
@@ -2424,7 +2426,7 @@ fn handleReviewFixLoop(
 
         var fix_out: std.ArrayList(u8) = .empty;
         defer fix_out.deinit(alloc);
-        runChainStep(alloc, "fixer", null, true, null, fix_prompt, 300, &fix_out);
+        runChainStep(alloc, "fixer", null, true, null, fix_prompt, 300 * std.time.ms_per_s, 300, &fix_out);
 
         iter_json.appendSlice(alloc, ",\"fix\":\"") catch return;
         mj.writeEscaped(alloc, &iter_json, fix_out.items);


### PR DESCRIPTION
## Summary
- **#405**: `saveToFile` takes a caller `Allocator`; add file round-trip test.
- Align `runChainStep` call sites with `timeout_ms` + `reported_timeout_seconds` (same fix as open #406).
- Add `scripts/zig-build.sh` for macOS (`DEVELOPER_DIR` → CLT) so Zig 0.15 links the build runner.

## Tests
- `./scripts/zig-build.sh`
- `./scripts/zig-build.sh test`
- Filtered: `storage`, `405`, `graph`

Closes #405
Supersedes / consolidates #406 (same runChainStep + script changes).

Made with [Cursor](https://cursor.com)