### PR TITLE
fix: PPR push threshold uses total out-weight (#109)

### DIFF
--- a/src/graph/ppr.zig
+++ b/src/graph/ppr.zig
@@ -3,7 +3,7 @@
 // Andersen-Chung-Lang push approximation for PPR.
 // Given a query node, computes relevance scores for all reachable nodes.
 //
-// Push rule: if r[u] > ε × deg(u), push u:
+// Push rule: if r[u] > ε × W_out(u), push u (W_out = total outgoing edge weight):
 //   p[u] += α × r[u]
 //   r[v] += (1-α) × r[u] × W(u,v) / W_out(u)  for each out-neighbour v
 //   r[u] = 0
@@ -27,7 +27,14 @@ pub const ScoredNode = struct {
 ///
 /// Returns a map of node_id → PPR score for all nodes with non-zero score.
 /// `alpha` is the teleport probability (typically 0.15).
-/// `epsilon` is the convergence threshold per unit of degree.
+/// `epsilon` scales the push threshold with total out-weight W_out(u) (not raw degree).
+fn totalOutWeight(g: *const CodeGraph, u: u64) f32 {
+    const edges = g.outEdges(u);
+    var s: f32 = 0;
+    for (edges) |e| s += e.weight;
+    return s;
+}
+
 pub fn pprPush(
     g: *const CodeGraph,
     query_node: u64,
@@ -69,11 +76,8 @@ pub fn pprPush(
         while (it.next()) |entry| {
             const u = entry.key_ptr.*;
             const r_u = entry.value_ptr.*;
-            const deg = g.outDegree(u);
-            const threshold = if (deg > 0)
-                epsilon * @as(f32, @floatFromInt(deg))
-            else
-                epsilon;
+            const w_out = totalOutWeight(g, u);
+            const threshold = if (w_out > 0) epsilon * w_out else epsilon;
             if (r_u > threshold) {
                 try to_push.append(alloc, u);
             }


### PR DESCRIPTION
## Summary
Push threshold now uses `epsilon * W_out(u)` (sum of outgoing edge weights) instead of `epsilon * degree(u)`, consistent with weighted residual distribution.

Closes #109

Made with [Cursor](https://cursor.com)