### PR TITLE
revert: undo merges from #407 and #408

### DIFF
--- a/scripts/zig-build.sh
+++ b/scripts/zig-build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# macOS: set DEVELOPER_DIR so Zig 0.15 can link the build runner (see PR #406).
-set -euo pipefail
-root="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$root"
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  export DEVELOPER_DIR="${DEVELOPER_DIR:-/Library/Developer/CommandLineTools}"
-fi
-exec "${ZIG:-zig}" build "$@"

--- a/src/graph/ppr.zig
+++ b/src/graph/ppr.zig
@@ -3,7 +3,7 @@
 // Andersen-Chung-Lang push approximation for PPR.
 // Given a query node, computes relevance scores for all reachable nodes.
 //
-// Push rule: if r[u] > ε × W_out(u), push u (W_out = total outgoing edge weight):
+// Push rule: if r[u] > ε × deg(u), push u:
 //   p[u] += α × r[u]
 //   r[v] += (1-α) × r[u] × W(u,v) / W_out(u)  for each out-neighbour v
 //   r[u] = 0
@@ -27,14 +27,7 @@ pub const ScoredNode = struct {
 ///
 /// Returns a map of node_id → PPR score for all nodes with non-zero score.
 /// `alpha` is the teleport probability (typically 0.15).
-/// `epsilon` scales the push threshold with total out-weight W_out(u) (not raw degree).
-fn totalOutWeight(g: *const CodeGraph, u: u64) f32 {
-    const edges = g.outEdges(u);
-    var s: f32 = 0;
-    for (edges) |e| s += e.weight;
-    return s;
-}
-
+/// `epsilon` is the convergence threshold per unit of degree.
 pub fn pprPush(
     g: *const CodeGraph,
     query_node: u64,
@@ -76,8 +69,11 @@ pub fn pprPush(
         while (it.next()) |entry| {
             const u = entry.key_ptr.*;
             const r_u = entry.value_ptr.*;
-            const w_out = totalOutWeight(g, u);
-            const threshold = if (w_out > 0) epsilon * w_out else epsilon;
+            const deg = g.outDegree(u);
+            const threshold = if (deg > 0)
+                epsilon * @as(f32, @floatFromInt(deg))
+            else
+                epsilon;
             if (r_u > threshold) {
                 try to_push.append(alloc, u);
             }

--- a/src/graph/storage.zig
+++ b/src/graph/storage.zig
@@ -188,15 +188,20 @@ pub fn deserialize(reader: anytype, alloc: std.mem.Allocator) !CodeGraph {
 
 // ── File I/O convenience ────────────────────────────────────────────────────
 
-/// Save a CodeGraph to a file path. `alloc` is used for the serialization buffer.
-pub fn saveToFile(g: *const CodeGraph, path: []const u8, alloc: std.mem.Allocator) !void {
+/// Save a CodeGraph to a file path.
+pub fn saveToFile(g: *const CodeGraph, path: []const u8) !void {
     const file = try std.fs.cwd().createFile(path, .{});
     defer file.close();
+    // Serialize to in-memory buffer, then write all at once
     var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(alloc);
-    try serialize(g, buf.writer(alloc));
+    defer buf.deinit(alloc_for_save);
+    try serialize(g, buf.writer(alloc_for_save));
     try file.writeAll(buf.items);
 }
+
+/// Temporary allocator for saveToFile — uses page_allocator since we
+/// don't have access to a caller-provided allocator in the current API.
+const alloc_for_save = std.heap.page_allocator;
 
 /// Load a CodeGraph from a file path.
 pub fn loadFromFile(path: []const u8, alloc: std.mem.Allocator) !CodeGraph {
@@ -873,31 +878,4 @@ test "round-trip with empty strings everywhere" {
     try std.testing.expectEqualStrings("", g2.getFile(1).?.path);
     try std.testing.expectEqualStrings("", g2.getCommit(1).?.author);
     try std.testing.expectEqualStrings("", g2.getCommit(1).?.message);
-}
-
-test "saveToFile and loadFromFile round-trip (#405)" {
-    const alloc = std.testing.allocator;
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir_abs = try tmp.dir.realpath(".", &dir_buf);
-    const path = try std.fs.path.join(alloc, &.{ dir_abs, "cgdb405.bin" });
-    defer alloc.free(path);
-
-    var g = CodeGraph.init(alloc);
-    defer g.deinit();
-    try g.addSymbol(.{ .id = 1, .name = "main", .kind = .function, .file_id = 1, .line = 1, .col = 0, .scope = "" });
-    try g.addFile(.{ .id = 1, .path = "src/x.zig", .language = .zig, .last_modified = 1, .hash = [_]u8{0} ** 32 });
-
-    try saveToFile(&g, path, alloc);
-    defer std.fs.cwd().deleteFile(path) catch {};
-
-    var g2 = try loadFromFile(path, alloc);
-    defer g2.deinit();
-
-    try std.testing.expectEqual(@as(usize, 1), g2.symbolCount());
-    try std.testing.expectEqualStrings("main", g2.getSymbol(1).?.name);
-    try std.testing.expectEqualStrings("src/x.zig", g2.getFile(1).?.path);
 }

--- a/src/tools.zig
+++ b/src/tools.zig
@@ -2166,9 +2166,7 @@ fn runAgentWithRole(
     timeout_seconds: ?u32,
     out: *std.ArrayList(u8),
 ) void {
-    const sec: u32 = timeout_seconds orelse 300;
-    const ms: u64 = @as(u64, sec) * std.time.ms_per_s;
-    runChainStep(alloc, role, mode, writable_flag, null, prompt, ms, sec, out);
+    runChainStep(alloc, role, mode, writable_flag, null, prompt, timeout_seconds, out);
 }
 
 fn parseTimeoutSeconds(args: *const std.json.ObjectMap, default_seconds: u32) u32 {
@@ -2219,7 +2217,7 @@ fn runChainStepWithBudget(
         appendTimedOutJson(alloc, step_out, total_timeout_seconds);
         return;
     };
-    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, @as(u64, remaining) * std.time.ms_per_s, remaining, step_out);
+    runChainStep(alloc, role, mode, writable_override, permission_mode, prompt, remaining, step_out);
 }
 
 fn handleRunReviewer(
@@ -2383,7 +2381,7 @@ fn handleReviewFixLoop(
         iter_json.appendSlice(alloc, ",\"review\":\"") catch return;
         var review_out: std.ArrayList(u8) = .empty;
         defer review_out.deinit(alloc);
-        runChainStep(alloc, "reviewer", null, false, null, review_prompt, 300 * std.time.ms_per_s, 300, &review_out);
+        runChainStep(alloc, "reviewer", null, false, null, review_prompt, 300, &review_out);
 
         mj.writeEscaped(alloc, &iter_json, review_out.items);
         iter_json.appendSlice(alloc, "\"") catch return;
@@ -2426,7 +2424,7 @@ fn handleReviewFixLoop(
 
         var fix_out: std.ArrayList(u8) = .empty;
         defer fix_out.deinit(alloc);
-        runChainStep(alloc, "fixer", null, true, null, fix_prompt, 300 * std.time.ms_per_s, 300, &fix_out);
+        runChainStep(alloc, "fixer", null, true, null, fix_prompt, 300, &fix_out);
 
         iter_json.appendSlice(alloc, ",\"fix\":\"") catch return;
         mj.writeEscaped(alloc, &iter_json, fix_out.items);


### PR DESCRIPTION
Reverts the squash commits from #407 and #408 on `main` (two `git revert` commits).

**Reason:** Those changes should not have been merged to `main` without explicit approval.

After this PR merges, `main` will match the pre-#407 state for those files.

Made with [Cursor](https://cursor.com)