### PR TITLE
fix: search.zig const/var compile failure (#426)

### DIFF
--- a/src/search.zig
+++ b/src/search.zig
@@ -312,14 +312,14 @@ test "extractIdentifierFromContext: leading whitespace" {
 
 test "searchRefs: empty symbol returns empty" {
     const alloc = std.testing.allocator;
-    const refs = try searchRefs(alloc, .rg, "", null);
+    var refs = try searchRefs(alloc, .rg, "", null);
     defer refs.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 0), refs.items.len);
 }
 
 test "searchRefs: none tool returns empty" {
     const alloc = std.testing.allocator;
-    const refs = try searchRefs(alloc, .none, "handleFoo", null);
+    var refs = try searchRefs(alloc, .none, "handleFoo", null);
     defer refs.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 0), refs.items.len);
 }


### PR DESCRIPTION
## Summary
- Changes `const refs` to `var refs` in two `searchRefs` tests (lines 315, 322) so `deinit` can take a mutable pointer.

## Test plan
- [x] `zig test src/search.zig` — all 24 tests pass (was failing before)
- [x] No other files changed

Fixes #426

Made with [Cursor](https://cursor.com)