### PR TITLE
fix: agent_sdk.zig — deduplicate doc comments and remove unused import (#427)

### DIFF
--- a/src/agent_sdk.zig
+++ b/src/agent_sdk.zig
@@ -13,9 +13,6 @@
 //   {"type":"result","subtype":"success","result":"<final text>",...}
 
 const std = @import("std");
-const mj  = @import("mcp").json;
-
-/// Options for a Claude agent run via `claude -p`.
 /// Options for a Claude agent run via `claude -p`.
 pub const AgentOptions = struct {
     /// Comma-separated tool allowlist, e.g. "Bash,Read,Edit".
@@ -56,12 +53,6 @@ pub fn runAgent(
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Attempts to run the turn via `claude -p`. Returns false when claude is
-/// unavailable so the caller can fall back to codex_appserver.
-/// Attempts to run the turn via `claude -p`. Returns false when claude is
-/// unavailable so the caller can fall back to codex_appserver.
-/// Attempts to run the turn via `claude -p`. Returns false when claude is
-/// unavailable so the caller can fall back to codex_appserver.
 /// Attempts to run the turn via `claude -p`. Returns false when claude is
 /// unavailable so the caller can fall back to codex_appserver.
 pub fn tryClaudeAgent(
@@ -168,9 +159,6 @@ pub fn tryClaudeAgent(
     return true;
 }
 
-/// Reads NDJSON from `claude -p --output-format stream-json`.
-/// Extracts the agent's final text from the `{"type":"result"}` event.
-/// Falls back to accumulated assistant-message text if no result event arrives.
 /// Reads NDJSON from `claude -p --output-format stream-json`.
 /// Extracts the agent's final text from the `{"type":"result"}` event.
 /// Falls back to accumulated assistant-message text if no result event arrives.


### PR DESCRIPTION
## Summary
- Removed 3x duplicated doc comments on `AgentOptions`, `tryClaudeAgent`, and `streamClaudeOutput`
- Removed unused `const mj = @import("mcp").json` import (line 16)
- Net: 12 lines deleted, zero behavior change

## Test plan
- [x] `zig ast-check src/agent_sdk.zig` passes
- [x] grep confirms no `mj.` usage in the file
- [x] Each public item now has exactly one doc comment block

Fixes #427

Made with [Cursor](https://cursor.com)